### PR TITLE
fix: serve index without breaking API routes

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,6 +7,7 @@ from typing import Dict, List
 from fastapi import APIRouter, Depends, FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
+from fastapi.responses import FileResponse
 
 from .etl.run import run_etl
 from .schemas.crypto import (
@@ -32,7 +33,6 @@ app.add_middleware(
 )
 
 static_dir = Path(__file__).resolve().parents[2] / "frontend"
-app.mount("/", StaticFiles(directory=static_dir, html=True), name="static")
 
 
 @lru_cache
@@ -162,6 +162,14 @@ def crypto_history(
 
 
 app.include_router(api)
+
+
+@app.get("/")
+def read_index() -> FileResponse:
+    return FileResponse(static_dir / "index.html")
+
+
+app.mount("/static", StaticFiles(directory=static_dir, html=True), name="static")
 
 
 @app.on_event("startup")

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from backend.app.main import app
+
+
+def test_root_serves_index_html() -> None:
+    client = TestClient(app)
+    response = client.get("/")
+    assert response.status_code == 200
+    index_file = Path(__file__).resolve().parents[1] / "frontend" / "index.html"
+    assert response.text == index_file.read_text()


### PR DESCRIPTION
## Summary
- serve index.html at root and move static assets to `/static`
- add regression test for root endpoint

## Testing
- `ruff check backend/app/main.py tests/test_root.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc4e4a7f94832780c7f3f8b12c3f4a