### PR TITLE
feat: expose and display version number

### DIFF
--- a/backend/app/core/version.py
+++ b/backend/app/core/version.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from pathlib import Path
+from subprocess import CalledProcessError, check_output
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def get_version() -> str:
+    """Return commit count as version string."""
+    try:
+        output = check_output(["git", "rev-list", "--count", "HEAD"], cwd=REPO_ROOT)
+        return output.decode().strip()
+    except (CalledProcessError, FileNotFoundError):
+        return "0"
+
+
+__all__ = ["get_version"]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -19,6 +19,8 @@ from .schemas.crypto import (
     Scores,
 )
 from .schemas.price import PriceResponse
+from .schemas.version import VersionResponse
+from .core.version import get_version
 from .services.coingecko import CoinGeckoClient
 
 app = FastAPI(title="Tokenlysis")
@@ -47,6 +49,12 @@ def get_coingecko_client() -> CoinGeckoClient:
 
 
 api = APIRouter(prefix="/api")
+
+
+@api.get("/version", response_model=VersionResponse)
+def read_version() -> VersionResponse:
+    """Return application version."""
+    return VersionResponse(version=get_version())
 
 
 @api.get("/price/{coin_id}", response_model=PriceResponse)

--- a/backend/app/schemas/version.py
+++ b/backend/app/schemas/version.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel
+
+
+class VersionResponse(BaseModel):
+    """Schema for API version response."""
+
+    version: str
+
+
+__all__ = ["VersionResponse"]

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -23,6 +23,7 @@
     </thead>
     <tbody></tbody>
   </table>
+  <p id="version"></p>
   <script>
     async function loadCryptos() {
       try {
@@ -41,7 +42,19 @@
         console.error(err);
       }
     }
+
+    async function loadVersion() {
+      try {
+        const res = await fetch('/api/version');
+        const data = await res.json();
+        document.getElementById('version').textContent = `Version: ${data.version}`;
+      } catch (err) {
+        document.getElementById('version').textContent = 'Version: unknown';
+        console.error(err);
+      }
+    }
     loadCryptos();
+    loadVersion();
   </script>
 </body>
 </html>

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,11 @@
+from backend.app.core.version import get_version
+from backend.app.main import app
+from fastapi.testclient import TestClient
+
+
+def test_version_endpoint() -> None:
+    client = TestClient(app)
+    expected = get_version()
+    response = client.get("/api/version")
+    assert response.status_code == 200
+    assert response.json() == {"version": expected}


### PR DESCRIPTION
## Summary
- expose `/api/version` endpoint returning commit count
- show version number in frontend footer
- test version endpoint

## Testing
- `ruff check backend/app/core/version.py backend/app/main.py tests/test_version.py`
- `ruff check backend/app/schemas/version.py`
- `black backend/app/core/version.py backend/app/main.py tests/test_version.py`
- `black backend/app/schemas/version.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc5b7bf0d483279194dcf63c149413