### PR TITLE
fix: support env version and proxy-aware ETL

### DIFF
--- a/backend/app/core/version.py
+++ b/backend/app/core/version.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from subprocess import CalledProcessError, check_output
 
@@ -8,11 +9,24 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def get_version() -> str:
-    """Return commit count as version string."""
+    """Return the application version.
+
+    The version is primarily derived from the git commit count. When git is not
+    available (e.g. in production images where the ``.git`` directory is not
+    copied or git isn't installed) the function falls back to the value of the
+    ``APP_VERSION`` environment variable. As a last resort it returns ``"0"``.
+    """
+
     try:
         output = check_output(["git", "rev-list", "--count", "HEAD"], cwd=REPO_ROOT)
         return output.decode().strip()
     except (CalledProcessError, FileNotFoundError):
+        env_version = os.getenv("APP_VERSION")
+        if env_version:
+            return env_version
+        version_file = REPO_ROOT / "VERSION"
+        if version_file.exists():
+            return version_file.read_text().strip()
         return "0"
 
 

--- a/backend/app/etl/run.py
+++ b/backend/app/etl/run.py
@@ -40,7 +40,6 @@ def _top_coins(limit: int) -> List[dict]:
             "page": 1,
         },
         timeout=30,
-        proxies={"http": None, "https": None},
     )
     resp.raise_for_status()
     return resp.json()
@@ -51,7 +50,6 @@ def _coin_history(coin_id: str, days: int) -> dict:
         f"{COINGECKO_API}/coins/{coin_id}/market_chart",
         params={"vs_currency": "usd", "days": days, "interval": "daily"},
         timeout=30,
-        proxies={"http": None, "https": None},
     )
     resp.raise_for_status()
     return resp.json()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,3 +3,4 @@ pydantic
 numpy
 uvicorn
 requests
+httpx

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,6 +1,8 @@
 from backend.app.core.version import get_version
 from backend.app.main import app
 from fastapi.testclient import TestClient
+from typing import Any
+import backend.app.core.version as version_module
 
 
 def test_version_endpoint() -> None:
@@ -9,3 +11,14 @@ def test_version_endpoint() -> None:
     response = client.get("/api/version")
     assert response.status_code == 200
     assert response.json() == {"version": expected}
+
+
+def test_get_version_env_fallback(monkeypatch) -> None:
+    """Ensure environment variable is used when git command fails."""
+    monkeypatch.setenv("APP_VERSION", "123")
+
+    def _raise(*args: Any, **kwargs: Any) -> bytes:
+        raise FileNotFoundError
+
+    monkeypatch.setattr(version_module, "check_output", _raise)
+    assert version_module.get_version() == "123"


### PR DESCRIPTION
## Summary
- allow reading version from `APP_VERSION` or VERSION file when git is absent
- remove hardcoded proxy disabling so CoinGecko requests respect environment proxies
- add httpx dependency and test coverage for version fallback

## Testing
- `ruff check backend/app/core/version.py backend/app/etl/run.py tests/test_version.py`
- `python -m black backend/app/core/version.py backend/app/etl/run.py tests/test_version.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc753aab3483278ca4624e04d872ae