### PR TITLE
chore: add environment variables to Docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.11-slim
 WORKDIR /app
+ENV APP_VERSION="123456789"
+ENV COINGECKO_API_KEY="XXXXX"
 COPY backend/requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 COPY backend ./backend

--- a/docker-compose.synology.yml
+++ b/docker-compose.synology.yml
@@ -6,6 +6,8 @@ services:
       context: https://github.com/Tomp0uce/Tokenlysis.git#main
     environment:
       - CORS_ORIGINS=http://localhost
+      - APP_VERSION=123456789
+      - COINGECKO_API_KEY=XXXXX
     ports:
       - "8002:8000"
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- expose APP_VERSION and COINGECKO_API_KEY in Dockerfile
- forward APP_VERSION and COINGECKO_API_KEY in docker-compose.synology.yml

## Testing
- `pip install -r backend/requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc7ce0be2c8327b044165951759001