### PR TITLE
fix: fetch live coingecko data and expose commit version

### DIFF
--- a/Dockerfile.synology
+++ b/Dockerfile.synology
@@ -5,7 +5,6 @@ ENV APP_VERSION="${APP_VERSION}"
 LABEL org.opencontainers.image.version="${APP_VERSION}"
 LABEL org.opencontainers.image.revision="${APP_VERSION}"
 WORKDIR /app
-ENV COINGECKO_API_KEY="XXXXX"
 COPY backend/requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 COPY backend ./backend

--- a/backend/app/services/coingecko.py
+++ b/backend/app/services/coingecko.py
@@ -42,5 +42,36 @@ class CoinGeckoClient:
         resp.raise_for_status()
         return resp.json()
 
+    def get_markets(
+        self,
+        vs_currency: str = "usd",
+        order: str = "market_cap_desc",
+        per_page: int = 20,
+        page: int = 1,
+    ) -> List[dict]:
+        """Return market data for a list of coins."""
+        url = f"{self.base_url}/coins/markets"
+        params = {
+            "vs_currency": vs_currency,
+            "order": order,
+            "per_page": per_page,
+            "page": page,
+        }
+        resp = self.session.get(url, params=params, timeout=30)
+        resp.raise_for_status()
+        return resp.json()
+
+    def get_market_chart(self, coin_id: str, days: int) -> dict:
+        """Return historical market chart for a coin."""
+        url = f"{self.base_url}/coins/{coin_id}/market_chart"
+        params = {
+            "vs_currency": "usd",
+            "days": days,
+            "interval": "daily",
+        }
+        resp = self.session.get(url, params=params, timeout=30)
+        resp.raise_for_status()
+        return resp.json()
+
 
 __all__ = ["CoinGeckoClient", "BASE_URL"]

--- a/docker-compose.synology.yml
+++ b/docker-compose.synology.yml
@@ -9,7 +9,7 @@ services:
         APP_VERSION: ${APP_VERSION:-dev}
     environment:
       - CORS_ORIGINS=http://localhost
-      - COINGECKO_API_KEY=XXXXX
+      - COINGECKO_API_KEY=${COINGECKO_API_KEY}
     ports:
       - "8002:8000"
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
         APP_VERSION: ${APP_VERSION:-dev}
     environment:
       - CORS_ORIGINS=http://localhost
+      - COINGECKO_API_KEY=${COINGECKO_API_KEY}
     ports:
       - "8002:8000"
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- read version from generated VERSION file or APP_VERSION
- add market endpoints to CoinGecko client and use them in ETL
- log and fall back to seed data on CoinGecko errors
- configure CoinGecko API key through compose files

## Testing
- `black --check backend/app/services/coingecko.py backend/app/etl/run.py backend/app/core/version.py`
- `ruff check backend/app/services/coingecko.py backend/app/etl/run.py backend/app/core/version.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc843f0cbc83279375b3013b79b29a