### PR TITLE
fix: handle detached HEAD in VERSION generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,18 @@ WORKDIR /app
 # APP_VERSION build argument is provided it is used instead.
 COPY .git /tmp/git
 RUN if [ "$APP_VERSION" = "dev" ]; then \
-      python - <<'PY' > VERSION
+        python - <<'PY' > VERSION
 import pathlib
-head = pathlib.Path('/tmp/git/HEAD').read_text().strip().split(' ')[1]
-print((pathlib.Path('/tmp/git') / head).read_text().strip())
+
+root = pathlib.Path('/tmp/git')
+head = (root / 'HEAD').read_text().strip()
+if head.startswith('ref:'):
+    ref = head.split(' ', 1)[1]
+    print((root / ref).read_text().strip())
+else:
+    print(head)
 PY
-    ; else echo "$APP_VERSION" > VERSION; fi && rm -rf /tmp/git
+      ; else echo "$APP_VERSION" > VERSION; fi && rm -rf /tmp/git
 COPY backend/requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 COPY backend ./backend

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,9 @@ root = pathlib.Path('/tmp/git')
 head = (root / 'HEAD').read_text().strip()
 if head.startswith('ref:'):
     ref = head.split(' ', 1)[1]
-    print((root / ref).read_text().strip())
+    print((root / ref).read_text().strip()[:7])
 else:
-    print(head)
+    print(head[:7])
 PY
       ; else echo "$APP_VERSION" > VERSION; fi && rm -rf /tmp/git
 COPY backend/requirements.txt ./

--- a/backend/app/core/version.py
+++ b/backend/app/core/version.py
@@ -18,11 +18,12 @@ def get_version() -> str:
 
     env_version = os.getenv("APP_VERSION")
     if env_version and env_version != "dev":
-        return env_version
+        return env_version[:7] if len(env_version) == 40 else env_version
 
     version_file = REPO_ROOT / "VERSION"
     if version_file.exists():
-        return version_file.read_text().strip()
+        version = version_file.read_text().strip()
+        return version[:7] if len(version) == 40 else version
 
     try:
         output = check_output(["git", "rev-parse", "--short", "HEAD"], cwd=REPO_ROOT)


### PR DESCRIPTION
## Summary
- handle detached HEAD when generating VERSION file in Docker build

## Testing
- `black --check backend/app/services/coingecko.py backend/app/etl/run.py backend/app/core/version.py`
- `ruff check backend/app/services/coingecko.py backend/app/etl/run.py backend/app/core/version.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc8aa53e0c8327b2d10689ab5771c4