### PR TITLE
fix: derive version from last merge at build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,22 +3,37 @@ FROM python:3.11-slim
 ARG APP_VERSION=dev
 WORKDIR /app
 
-# Generate a VERSION file containing the current commit hash. When a specific
-# APP_VERSION build argument is provided it is used instead.
+# Derive a version string from the last commit timestamp when no explicit APP_VERSION is provided.
 COPY .git /tmp/git
 RUN if [ "$APP_VERSION" = "dev" ]; then \
         python - <<'PY' > VERSION
-import pathlib
+import datetime, pathlib, zlib
 
 root = pathlib.Path('/tmp/git')
 head = (root / 'HEAD').read_text().strip()
 if head.startswith('ref:'):
     ref = head.split(' ', 1)[1]
-    print((root / ref).read_text().strip()[:7])
+    commit = (root / ref).read_text().strip()
 else:
-    print(head[:7])
+    commit = head.strip()
+obj = root / 'objects' / commit[:2] / commit[2:]
+data = zlib.decompress(obj.read_bytes())
+for line in data.splitlines():
+    if line.startswith(b'committer '):
+        parts = line.split()
+        ts = int(parts[-2])
+        tz = parts[-1].decode()
+        sign = 1 if tz[0] == '+' else -1
+        hours = int(tz[1:3])
+        minutes = int(tz[3:5])
+        offset = datetime.timedelta(hours=hours, minutes=minutes) * sign
+        dt = datetime.datetime.fromtimestamp(ts, datetime.timezone(offset))
+        print(dt.isoformat())
+        break
 PY
-      ; else echo "$APP_VERSION" > VERSION; fi && rm -rf /tmp/git
+    else \
+        echo "$APP_VERSION" > VERSION; \
+    fi && rm -rf /tmp/git
 COPY backend/requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 COPY backend ./backend

--- a/Dockerfile.synology
+++ b/Dockerfile.synology
@@ -1,10 +1,39 @@
 # syntax=docker/dockerfile:1
 FROM python:3.11-slim
 ARG APP_VERSION=dev
-ENV APP_VERSION="${APP_VERSION}"
-LABEL org.opencontainers.image.version="${APP_VERSION}"
-LABEL org.opencontainers.image.revision="${APP_VERSION}"
 WORKDIR /app
+
+# Derive a version string from the last commit timestamp when no explicit APP_VERSION is provided.
+COPY .git /tmp/git
+RUN if [ "$APP_VERSION" = "dev" ]; then \
+        python - <<'PY' > VERSION
+import datetime, pathlib, zlib
+
+root = pathlib.Path('/tmp/git')
+head = (root / 'HEAD').read_text().strip()
+if head.startswith('ref:'):
+    ref = head.split(' ', 1)[1]
+    commit = (root / ref).read_text().strip()
+else:
+    commit = head.strip()
+obj = root / 'objects' / commit[:2] / commit[2:]
+data = zlib.decompress(obj.read_bytes())
+for line in data.splitlines():
+    if line.startswith(b'committer '):
+        parts = line.split()
+        ts = int(parts[-2])
+        tz = parts[-1].decode()
+        sign = 1 if tz[0] == '+' else -1
+        hours = int(tz[1:3])
+        minutes = int(tz[3:5])
+        offset = datetime.timedelta(hours=hours, minutes=minutes) * sign
+        dt = datetime.datetime.fromtimestamp(ts, datetime.timezone(offset))
+        print(dt.isoformat())
+        break
+PY
+    else \
+        echo "$APP_VERSION" > VERSION; \
+    fi && rm -rf /tmp/git
 COPY backend/requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 COPY backend ./backend

--- a/docker-compose.synology.yml
+++ b/docker-compose.synology.yml
@@ -6,7 +6,7 @@ services:
       context: https://github.com/Tomp0uce/Tokenlysis.git#main
       dockerfile: Dockerfile.synology
       args:
-        APP_VERSION: ${APP_VERSION:-dev}
+        APP_VERSION: "${APP_VERSION:-dev}"
     environment:
       - CORS_ORIGINS=http://localhost
       - COINGECKO_API_KEY=${COINGECKO_API_KEY}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: .
       args:
-        APP_VERSION: ${APP_VERSION:-dev}
+        APP_VERSION: "${APP_VERSION:-dev}"
     environment:
       - CORS_ORIGINS=http://localhost
       - COINGECKO_API_KEY=${COINGECKO_API_KEY}


### PR DESCRIPTION
## Summary
- compute image version from last commit timestamp when APP_VERSION is unset
- pass default build arg through docker-compose files for automatic versioning

## Testing
- `pip install -r backend/requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc8f9968408327a21aa220116e12f8