### PR TITLE
build: add synology compose and ignore custom Dockerfiles

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          mapfile -t DFS < <(git ls-files | grep -Ei '(^|/)Dockerfile(\..*)?$' || true)
+          mapfile -t DFS < <(git ls-files | grep -Ei '(^|/)Dockerfile$' || true)
           if [ ${#DFS[@]} -eq 0 ]; then
             echo "No Dockerfile found."; exit 0
           fi
@@ -67,7 +67,7 @@ jobs:
       #   run: |
       #     set -euo pipefail
       #     OWNER_LC="$(echo "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
-      #     mapfile -t DFS < <(git ls-files | grep -Ei '(^|/)Dockerfile(\..*)?$' || true)
+      #     mapfile -t DFS < <(git ls-files | grep -Ei '(^|/)Dockerfile$' || true)
       #     for DF in "${DFS[@]}"; do
       #       CTX="$(dirname "$DF")"
       #       NAME="$(basename "$CTX")"

--- a/Dockerfile.synology
+++ b/Dockerfile.synology
@@ -1,4 +1,6 @@
 # syntax=docker/dockerfile:1
+# DEPRECATED: this file is kept for reference. Use the root Dockerfile with
+# `docker-compose.synology.yml` instead.
 FROM python:3.11-slim
 ARG APP_VERSION=dev
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -111,7 +111,10 @@ Docker Compose fetch the source code automatically.
    ```
 
    This compose file contains a `build` section pointing directly to the Git
-   repository so the code is downloaded during the first build.
+   repository so the code is downloaded during the first build. It uses the
+   repository's standard `Dockerfile` and forwards an optional
+   `APP_VERSION` build argument. Define `APP_VERSION` to pin a specific version
+   or let it default to `dev`. The legacy `Dockerfile.synology` is deprecated.
 3. **Confirm settings** – keep port `8002` exposed (or change if needed) and
    create the project. The initial `docker compose up` will clone the
    repository, build the image and start the container.

--- a/docker-compose.synology.yml
+++ b/docker-compose.synology.yml
@@ -4,7 +4,7 @@ services:
     container_name: tokenlysis
     build:
       context: https://github.com/Tomp0uce/Tokenlysis.git#main
-      dockerfile: Dockerfile.synology
+      dockerfile: Dockerfile
       args:
         APP_VERSION: "${APP_VERSION:-dev}"
     environment:


### PR DESCRIPTION
## Summary
- build Synology images using the main Dockerfile via `docker-compose.synology.yml`
- skip custom Dockerfile variants in CI builds
- document Synology usage and deprecate `Dockerfile.synology`

## Testing
- `pip install -r backend/requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc93c2b5148327b78b2b0125ee5d6f