### PR TITLE
build: derive Docker version from commit date

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+.github
+tests
+*.md

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,8 +18,8 @@ jobs:
 
       - name: Compute version from commit
         run: |
-          echo "APP_VERSION_SHORT=${GITHUB_SHA::7}" >> $GITHUB_ENV
-          echo "APP_VERSION_FULL=${GITHUB_SHA}" >> $GITHUB_ENV
+          echo "APP_VERSION=$(git show -s --format=%cI HEAD)" >> $GITHUB_ENV
+          echo "GIT_COMMIT=${GITHUB_SHA}" >> $GITHUB_ENV
 
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v3
@@ -54,8 +54,8 @@ jobs:
             [ "$NAME" = "." ] && NAME="tokenlysis"
             echo ">>> Building $DF (context: $CTX, name: $NAME)"
             docker buildx build \
-              --build-arg APP_VERSION="${APP_VERSION_SHORT}" \
-              --label "org.opencontainers.image.revision=${APP_VERSION_FULL}" \
+              --build-arg APP_VERSION="${APP_VERSION}" \
+              --label "org.opencontainers.image.revision=${GIT_COMMIT}" \
               -f "$DF" "$CTX" \
               --load   # charge l'image localement pour validation (pas de push)
           done
@@ -74,10 +74,10 @@ jobs:
       #       [ "$NAME" = "." ] && NAME="tokenlysis"
       #       echo ">>> Build & push $DF (context: $CTX, name: $NAME)"
       #       docker buildx build \
-      #         --build-arg APP_VERSION="${APP_VERSION_SHORT}" \
-      #         --label "org.opencontainers.image.revision=${APP_VERSION_FULL}" \
+      #         --build-arg APP_VERSION="${APP_VERSION}" \
+      #         --label "org.opencontainers.image.revision=${GIT_COMMIT}" \
       #         -f "$DF" "$CTX" \
       #         --push \
-      #         -t "ghcr.io/${OWNER_LC}/${NAME}:${APP_VERSION_SHORT}" \
+      #         -t "ghcr.io/${OWNER_LC}/${NAME}:${APP_VERSION}" \
       #         -t "ghcr.io/${OWNER_LC}/${NAME}:latest"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,9 @@
 # syntax=docker/dockerfile:1
 FROM python:3.11-slim
-ARG APP_VERSION=dev
+ARG APP_VERSION
 WORKDIR /app
 
-# Derive a version string from the last commit timestamp when no explicit APP_VERSION is provided.
-COPY .git /tmp/git
-RUN if [ "$APP_VERSION" = "dev" ]; then \
-        python - <<'PY' > VERSION
-import datetime, pathlib, zlib
-
-root = pathlib.Path('/tmp/git')
-head = (root / 'HEAD').read_text().strip()
-if head.startswith('ref:'):
-    ref = head.split(' ', 1)[1]
-    commit = (root / ref).read_text().strip()
-else:
-    commit = head.strip()
-obj = root / 'objects' / commit[:2] / commit[2:]
-data = zlib.decompress(obj.read_bytes())
-for line in data.splitlines():
-    if line.startswith(b'committer '):
-        parts = line.split()
-        ts = int(parts[-2])
-        tz = parts[-1].decode()
-        sign = 1 if tz[0] == '+' else -1
-        hours = int(tz[1:3])
-        minutes = int(tz[3:5])
-        offset = datetime.timedelta(hours=hours, minutes=minutes) * sign
-        dt = datetime.datetime.fromtimestamp(ts, datetime.timezone(offset))
-        print(dt.isoformat())
-        break
-PY
-    else \
-        echo "$APP_VERSION" > VERSION; \
-    fi && rm -rf /tmp/git
+RUN echo "$APP_VERSION" > VERSION
 COPY backend/requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 COPY backend ./backend


### PR DESCRIPTION
## Summary
- derive app version from commit date in CI and pass to Docker builds
- simplify Dockerfile to use provided APP_VERSION
- ignore VCS and docs in Docker build context

## Testing
- `pip install -r backend/requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc968bee90832799eb10b5edd3386e