### PR TITLE
fix: parse CORS origins env variable

### DIFF
--- a/backend/app/core/settings.py
+++ b/backend/app/core/settings.py
@@ -11,7 +11,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 class Settings(BaseSettings):
     """Application settings loaded from environment and optional files."""
 
-    cors_origins: List[str] = ["http://localhost"]
+    cors_origins: List[str] | str = ["http://localhost"]
     cg_top_n: int = 20
     cg_days: int = 14
     coingecko_api_key: Optional[str] = None

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -22,3 +22,15 @@ def test_api_key_from_secret_file(monkeypatch):
         assert get_coingecko_headers(cfg) == {"x-cg-pro-api-key": "file-key"}
     finally:
         secret_file.unlink()
+
+
+def test_cors_origins_parsing(monkeypatch):
+    monkeypatch.setenv("CORS_ORIGINS", "http://a.com, http://b.com")
+    cfg = Settings()
+    assert cfg.cors_origins == ["http://a.com", "http://b.com"]
+
+
+def test_empty_cors_origins(monkeypatch):
+    monkeypatch.setenv("CORS_ORIGINS", "")
+    cfg = Settings()
+    assert cfg.cors_origins == []


### PR DESCRIPTION
## Summary
- allow comma-separated `CORS_ORIGINS` env var values
- test CORS origins parsing including empty values

## Testing
- `ruff check backend/app/core/settings.py tests/test_settings.py`
- `black backend/app/core/settings.py tests/test_settings.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bcae11b19c8327a87fe53108c54530