### PR TITLE
feat: expose debug info and commit timestamp

### DIFF
--- a/backend/app/core/version.py
+++ b/backend/app/core/version.py
@@ -13,7 +13,8 @@ def get_version() -> str:
     Prefer the ``APP_VERSION`` environment variable when set to a value other
     than the placeholder ``dev``. When not provided, attempt to read the
     version from a VERSION file generated at build time. As a final fallback,
-    retrieve the short git commit hash. If everything fails, return ``"0"``.
+    retrieve the commit date and time from git. If everything fails, return
+    ``"0"``.
     """
 
     env_version = os.getenv("APP_VERSION")
@@ -26,7 +27,9 @@ def get_version() -> str:
         return version[:7] if len(version) == 40 else version
 
     try:
-        output = check_output(["git", "rev-parse", "--short", "HEAD"], cwd=REPO_ROOT)
+        output = check_output(
+            ["git", "log", "-1", "--format=%cd", "--date=iso"], cwd=REPO_ROOT
+        )
         return output.decode().strip()
     except (CalledProcessError, FileNotFoundError):
         return env_version or "0"

--- a/backend/app/debug.py
+++ b/backend/app/debug.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+# DEBUG: temporary debug utilities
+
+from subprocess import run
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from .core.settings import settings
+from .services.coingecko import CoinGeckoClient
+
+
+def get_coingecko_client() -> CoinGeckoClient:  # DEBUG: local copy
+    return CoinGeckoClient()
+
+
+router = APIRouter()
+
+
+class DebugInfo(BaseModel):
+    coingecko_command: str
+    api_key: str | None
+    ping_command: str
+    ping_response: str
+
+
+@router.get("/debug", response_model=DebugInfo)
+# DEBUG: endpoint exposing internal commands
+async def get_debug_info(
+    client: CoinGeckoClient = Depends(get_coingecko_client),
+) -> DebugInfo:
+    limit = settings.cg_top_n
+    url = (
+        f"{client.base_url}/coins/markets?vs_currency=usd&order=market_cap_desc"
+        f"&per_page={limit}&page=1"
+    )
+    api_key = client.api_key
+    header = f"-H 'x-cg-pro-api-key: {api_key}' " if api_key else ""
+    coingecko_command = f"curl {header}'{url}'"
+
+    ping_command = "ping -c 1 api.coingecko.com"
+    proc = run(ping_command.split(), capture_output=True, text=True)
+    ping_response = proc.stdout or proc.stderr
+
+    return DebugInfo(
+        coingecko_command=coingecko_command,
+        api_key=api_key,
+        ping_command=ping_command,
+        ping_response=ping_response,
+    )
+
+
+__all__ = ["router"]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -22,6 +22,7 @@ from .schemas.version import VersionResponse
 from .core.version import get_version
 from .core.settings import settings
 from .services.coingecko import CoinGeckoClient
+from .debug import router as debug_router  # DEBUG
 
 app = FastAPI(title="Tokenlysis")
 app.add_middleware(
@@ -48,6 +49,9 @@ def get_coingecko_client() -> CoinGeckoClient:
 
 
 api = APIRouter(prefix="/api")
+
+# DEBUG: include debug routes
+api.include_router(debug_router)
 
 
 @api.get("/version", response_model=VersionResponse)

--- a/frontend/debug.js
+++ b/frontend/debug.js
@@ -1,0 +1,18 @@
+/* DEBUG: temporary debug script */
+async function loadDebug() {
+  try {
+    const res = await fetch('/api/debug');
+    const data = await res.json();
+    const div = document.createElement('pre');
+    div.id = 'debug';
+    div.textContent =
+      `Coingecko command: ${data.coingecko_command}\n` +
+      `API key: ${data.api_key}\n` +
+      `Ping command: ${data.ping_command}\n` +
+      `Ping response: ${data.ping_response}`;
+    document.body.appendChild(div);
+  } catch (err) {
+    console.error('debug error', err);
+  }
+}
+loadDebug();

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -56,5 +56,7 @@
     loadCryptos();
     loadVersion();
   </script>
+  <!-- DEBUG: include debug script -->
+  <script src="debug.js"></script>
 </body>
 </html>

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -1,0 +1,21 @@
+from subprocess import CompletedProcess
+
+from backend.app.main import app
+from fastapi.testclient import TestClient
+
+
+def test_debug_endpoint(monkeypatch):
+    client = TestClient(app)
+
+    def fake_run(cmd, capture_output, text):
+        return CompletedProcess(cmd, 0, stdout="pong", stderr="")
+
+    monkeypatch.setenv("COINGECKO_API_KEY", "test-key")
+    monkeypatch.setattr("backend.app.debug.run", fake_run)
+
+    resp = client.get("/api/debug")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["api_key"] == "test-key"
+    assert "coins/markets" in data["coingecko_command"]
+    assert data["ping_response"] == "pong"


### PR DESCRIPTION
## Summary
- show commit date/time as version
- add debug endpoint exposing CoinGecko request, API key, and ping
- display debug info on frontend and test endpoint

## Testing
- `black backend/app/debug.py backend/app/main.py backend/app/core/version.py tests/test_debug.py`
- `ruff check backend/app/core/version.py backend/app/debug.py backend/app/main.py tests/test_debug.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd201f1cf48327b392a22ccd8fadf7