### PR TITLE
fix(frontend): remove import.meta usage in dashboard

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,6 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
+  <meta name="api-url" content="/api">
   <title>Tokenlysis Dashboard</title>
   <style>
     body { font-family: Arial, sans-serif; margin: 20px; }
@@ -25,7 +26,7 @@
   </table>
   <p id="version"></p>
   <script>
-    const API_URL = import.meta.env.VITE_API_URL || '';
+    const API_URL = document.querySelector('meta[name="api-url"]')?.content || '';
 
     async function loadCryptos() {
       try {


### PR DESCRIPTION
## Summary
- define API URL via static meta tag
- query meta tag instead of unsupported `import.meta`

## Testing
- `ruff check backend/app/core/settings.py backend/app/services/coingecko.py tests/test_settings.py tests/test_coingecko.py tests/test_debug.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd75918e788327bffd2c403a63264d