### PR TITLE
feat: use commit count as app version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,9 +16,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Compute version from commit
+      - name: Compute version from commit count
         run: |
-          echo "APP_VERSION=$(git show -s --format=%cI HEAD)" >> $GITHUB_ENV
+          echo "APP_VERSION=$(git rev-list --count HEAD)" >> $GITHUB_ENV
           echo "GIT_COMMIT=${GITHUB_SHA}" >> $GITHUB_ENV
 
       - name: Set up Buildx


### PR DESCRIPTION
## Summary
- derive version number from total commit count
- update docs and tests for new version scheme
- compute commit count in build workflow instead of timestamp

## Testing
- `ruff check backend/app/core/version.py tests/test_version.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd79728f70832783c3b6d07985b179