### PR TITLE
fix: validate env vars and mask secrets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,8 @@
 APP_VERSION=dev
 CORS_ORIGINS=http://localhost
-COINGECKO_API_KEY=
 CG_TOP_N=20
 CG_DAYS=14
 USE_SEED_ON_FAILURE=false
 LOG_LEVEL=INFO
+# COINGECKO_API_KEY=your_pro_key  # set only if you have a CoinGecko Pro plan
 # DB_PASSWORD=  # reserved for MVP

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ Tokenlysis is a platform that ranks over 1,000 crypto-assets each day. It comput
 - Use HTTPS in production and apply rate limiting on public APIs.
 - Store passwords hashed and keep dependencies updated with tools like `pip-audit`.
 - Mask secrets in logs and diagnostic endpoints.
+- Avoid writing empty environment variables; fall back to defaults when values are blank and raise clear errors for invalid entries.
 
 ## Documentation
 - Update the README when the feature scope evolves.

--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ Runtime behaviour can be tweaked with environment variables:
 - `USE_SEED_ON_FAILURE` – fall back to bundled seed data when live ETL fails (default: `false`)
 - `LOG_LEVEL` – set to `DEBUG` for verbose logs (default: `INFO`)
 
+Boolean variables accept `true/false/1/0/yes/no/on/off` (case-insensitive). Empty values fall back to defaults, while unrecognised values trigger a startup error. Integer variables behave similarly: empty strings use the default and invalid numbers raise an explicit error.
+
 The ETL fetches market data using CoinGecko's coin IDs. During development the
 seed assets (`C1`, `C2`, …) are mapped to real CoinGecko IDs through
 `backend/app/config/seed_mapping.py`.

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,6 +1,7 @@
 import importlib
 
 import backend.app.core.settings as settings_module
+import pytest
 
 
 def test_api_key_from_env(monkeypatch):
@@ -8,6 +9,13 @@ def test_api_key_from_env(monkeypatch):
     importlib.reload(settings_module)
     assert settings_module.COINGECKO_API_KEY == "env-key"
     assert settings_module.get_coingecko_headers() == {"x-cg-pro-api-key": "env-key"}
+
+
+def test_empty_api_key(monkeypatch):
+    monkeypatch.setenv("COINGECKO_API_KEY", "")
+    importlib.reload(settings_module)
+    assert settings_module.COINGECKO_API_KEY is None
+    assert settings_module.get_coingecko_headers() == {}
 
 
 def test_cors_origins_parsing(monkeypatch):
@@ -20,3 +28,44 @@ def test_empty_cors_origins(monkeypatch):
     monkeypatch.setenv("CORS_ORIGINS", "")
     cfg = settings_module.Settings()
     assert cfg.cors_origins == []
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("", False),
+        (" ", False),
+        ("true", True),
+        ("FALSE", False),
+        ("1", True),
+        ("0", False),
+        ("yes", True),
+        ("No", False),
+    ],
+)
+def test_bool_parsing(monkeypatch, value, expected):
+    monkeypatch.setenv("USE_SEED_ON_FAILURE", value)
+    cfg = settings_module.Settings()
+    assert cfg.use_seed_on_failure is expected
+
+
+def test_invalid_bool(monkeypatch):
+    monkeypatch.setenv("USE_SEED_ON_FAILURE", "maybe")
+    with pytest.raises(
+        ValueError, match="Invalid boolean 'maybe' for USE_SEED_ON_FAILURE"
+    ):
+        settings_module.Settings()
+
+
+def test_int_parsing(monkeypatch):
+    monkeypatch.setenv("CG_TOP_N", "")
+    cfg = settings_module.Settings()
+    assert cfg.cg_top_n == 20
+
+    monkeypatch.setenv("CG_TOP_N", "abc")
+    with pytest.raises(ValueError, match="Invalid integer 'abc' for CG_TOP_N"):
+        settings_module.Settings()
+
+
+def test_mask_secret():
+    assert settings_module.mask_secret("abcdef1234") == "******1234"


### PR DESCRIPTION
## Summary
- validate boolean and integer environment variables with explicit errors
- add helper to mask secrets and avoid empty env vars
- document new env parsing rules and update examples

## Testing
- `ruff check backend tests`
- `black backend tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd818ab1a88327945697ede2306368