### PR TITLE
fix: harden logging and env settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,4 +5,4 @@ CG_DAYS=14
 USE_SEED_ON_FAILURE=false
 LOG_LEVEL=INFO
 # COINGECKO_API_KEY=your_pro_key  # set only if you have a CoinGecko Pro plan
-# DB_PASSWORD=  # reserved for MVP
+# DB_PASSWORD=your_db_password  # reserved for MVP

--- a/README.md
+++ b/README.md
@@ -152,8 +152,10 @@ the local source code.
    **Create** and select the `docker-compose.yml` file from the cloned folder.
    Add `docker-compose.synology.yml` as an additional compose file so the image
    is built locally. When defining environment variables in the Synology UI,
-   never leave a value empty; either remove the variable or provide a valid
-   value.
+   never leave a value empty. If you don't have a value, remove the variable
+   instead of leaving it blank. Supported boolean values are `true`, `false`,
+   `1`, `0`, `yes`, `no`, `on` and `off` (case-insensitive); an empty value is
+   treated as unset and defaults are applied.
 4. **Build and start** – from the NAS terminal run:
 
    ```bash

--- a/README.md
+++ b/README.md
@@ -110,16 +110,20 @@ Runtime behaviour can be tweaked with environment variables:
 - `COINGECKO_API_KEY` – optional API key for the CoinGecko Pro plan
 - `USE_SEED_ON_FAILURE` – fall back to bundled seed data when live ETL fails (default: `false`)
 - `LOG_LEVEL` – base logging level for application and Uvicorn loggers (default: `INFO`).
+  Accepts an integer or one of
+  `DEBUG`, `INFO`, `WARN`, `WARNING`, `ERROR`, `CRITICAL`, `FATAL` or `NOTSET`.
   Unknown values fall back to `INFO` with a warning. Use `UVICORN_LOG_LEVEL` or
   `--log-level` to override server log level separately.
 
 Do **not** define environment variables with empty values. If a value is not
 needed, remove the variable or comment it out in `.env`. On Synology, delete the
-variable from the UI instead of leaving the field blank. `LOG_LEVEL` accepts an
-integer or one of `CRITICAL`, `ERROR`, `WARNING`, `INFO`, `DEBUG` or `NOTSET`;
-other values fall back to `INFO` (warning logged).
+variable from the UI instead of leaving the field blank. Quotes around values
+(e.g. `LOG_LEVEL="INFO"`) are ignored.
 
-Boolean variables accept `true/false/1/0/yes/no/on/off` (case-insensitive). Empty values fall back to defaults, while unrecognised values trigger a startup error. Integer variables behave similarly: empty strings use the default and invalid numbers raise an explicit error.
+Boolean variables accept `true/false/1/0/yes/no/on/off` (case-insensitive, surrounding
+whitespace allowed). Empty or unrecognised values fall back to their defaults.
+Integer variables behave similarly: empty strings use the default and invalid numbers
+raise an explicit error.
 
 The ETL fetches market data using CoinGecko's coin IDs. During development the
 seed assets (`C1`, `C2`, …) are mapped to real CoinGecko IDs through

--- a/README.md
+++ b/README.md
@@ -110,10 +110,12 @@ Runtime behaviour can be tweaked with environment variables:
 - `COINGECKO_API_KEY` – optional API key for the CoinGecko Pro plan
 - `USE_SEED_ON_FAILURE` – fall back to bundled seed data when live ETL fails (default: `false`)
 - `LOG_LEVEL` – set to `DEBUG` for verbose logs (default: `INFO`)
+  (application logs only; server logs use `UVICORN_LOG_LEVEL` or `--log-level`)
 
 Do **not** define environment variables with empty values. If a value is not
 needed, remove the variable or comment it out in `.env`. `LOG_LEVEL` accepts an
-integer or one of `CRITICAL`, `ERROR`, `WARNING`, `INFO`, `DEBUG` or `NOTSET`.
+integer or one of `CRITICAL`, `ERROR`, `WARNING`, `INFO`, `DEBUG` or `NOTSET`;
+any other value causes a startup error.
 
 Boolean variables accept `true/false/1/0/yes/no/on/off` (case-insensitive). Empty values fall back to defaults, while unrecognised values trigger a startup error. Integer variables behave similarly: empty strings use the default and invalid numbers raise an explicit error.
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ Runtime behaviour can be tweaked with environment variables:
 - `USE_SEED_ON_FAILURE` – fall back to bundled seed data when live ETL fails (default: `false`)
 - `LOG_LEVEL` – set to `DEBUG` for verbose logs (default: `INFO`)
 
+Do **not** define environment variables with empty values. If a value is not
+needed, remove the variable or comment it out in `.env`. `LOG_LEVEL` accepts an
+integer or one of `CRITICAL`, `ERROR`, `WARNING`, `INFO`, `DEBUG` or `NOTSET`.
+
 Boolean variables accept `true/false/1/0/yes/no/on/off` (case-insensitive). Empty values fall back to defaults, while unrecognised values trigger a startup error. Integer variables behave similarly: empty strings use the default and invalid numbers raise an explicit error.
 
 The ETL fetches market data using CoinGecko's coin IDs. During development the
@@ -147,7 +151,9 @@ the local source code.
 3. **Create the project** – in **Container Manager**, go to **Project** →
    **Create** and select the `docker-compose.yml` file from the cloned folder.
    Add `docker-compose.synology.yml` as an additional compose file so the image
-   is built locally.
+   is built locally. When defining environment variables in the Synology UI,
+   never leave a value empty; either remove the variable or provide a valid
+   value.
 4. **Build and start** – from the NAS terminal run:
 
    ```bash

--- a/README.md
+++ b/README.md
@@ -110,12 +110,13 @@ Runtime behaviour can be tweaked with environment variables:
 - `COINGECKO_API_KEY` – optional API key for the CoinGecko Pro plan
 - `USE_SEED_ON_FAILURE` – fall back to bundled seed data when live ETL fails (default: `false`)
 - `LOG_LEVEL` – set to `DEBUG` for verbose logs (default: `INFO`)
-  (application logs only; server logs use `UVICORN_LOG_LEVEL` or `--log-level`)
+  (application logs only; server logs use `UVICORN_LOG_LEVEL` or `--log-level`).
+  Unknown values fall back to `INFO` and log a warning.
 
 Do **not** define environment variables with empty values. If a value is not
 needed, remove the variable or comment it out in `.env`. `LOG_LEVEL` accepts an
 integer or one of `CRITICAL`, `ERROR`, `WARNING`, `INFO`, `DEBUG` or `NOTSET`;
-any other value causes a startup error.
+other values fall back to `INFO` (warning logged).
 
 Boolean variables accept `true/false/1/0/yes/no/on/off` (case-insensitive). Empty values fall back to defaults, while unrecognised values trigger a startup error. Integer variables behave similarly: empty strings use the default and invalid numbers raise an explicit error.
 

--- a/README.md
+++ b/README.md
@@ -109,12 +109,13 @@ Runtime behaviour can be tweaked with environment variables:
 - `CG_DAYS` – number of days of history to retrieve (default: `14`)
 - `COINGECKO_API_KEY` – optional API key for the CoinGecko Pro plan
 - `USE_SEED_ON_FAILURE` – fall back to bundled seed data when live ETL fails (default: `false`)
-- `LOG_LEVEL` – set to `DEBUG` for verbose logs (default: `INFO`)
-  (application logs only; server logs use `UVICORN_LOG_LEVEL` or `--log-level`).
-  Unknown values fall back to `INFO` and log a warning.
+- `LOG_LEVEL` – base logging level for application and Uvicorn loggers (default: `INFO`).
+  Unknown values fall back to `INFO` with a warning. Use `UVICORN_LOG_LEVEL` or
+  `--log-level` to override server log level separately.
 
 Do **not** define environment variables with empty values. If a value is not
-needed, remove the variable or comment it out in `.env`. `LOG_LEVEL` accepts an
+needed, remove the variable or comment it out in `.env`. On Synology, delete the
+variable from the UI instead of leaving the field blank. `LOG_LEVEL` accepts an
 integer or one of `CRITICAL`, `ERROR`, `WARNING`, `INFO`, `DEBUG` or `NOTSET`;
 other values fall back to `INFO` (warning logged).
 

--- a/backend/app/core/settings.py
+++ b/backend/app/core/settings.py
@@ -23,12 +23,6 @@ FALSE_VALUES = {"0", "false", "f", "no", "n", "off"}
 def _coerce_bool(value: Any, default: bool, env_name: str) -> bool:
     if value is None:
         return default
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, int):
-        if value in (0, 1):
-            return bool(value)
-        raise ValueError(f"Invalid boolean integer '{value}' for {env_name}")
     if isinstance(value, str):
         s = value.strip()
         if s == "":
@@ -39,6 +33,12 @@ def _coerce_bool(value: Any, default: bool, env_name: str) -> bool:
         if sl in FALSE_VALUES:
             return False
         raise ValueError(f"Invalid boolean '{value}' for {env_name}")
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        if value in (0, 1):
+            return bool(value)
+        raise ValueError(f"Invalid boolean integer '{value}' for {env_name}")
     raise ValueError(f"Invalid boolean type '{type(value).__name__}' for {env_name}")
 
 

--- a/backend/app/core/settings.py
+++ b/backend/app/core/settings.py
@@ -20,7 +20,7 @@ TRUE_VALUES = {"1", "true", "t", "yes", "y", "on"}
 FALSE_VALUES = {"0", "false", "f", "no", "n", "off"}
 
 
-def _coerce_bool(value: Any, default: bool) -> bool:
+def _coerce_bool(value: Any, default: bool, env_name: str) -> bool:
     if value is None:
         return default
     if isinstance(value, bool):
@@ -28,7 +28,7 @@ def _coerce_bool(value: Any, default: bool) -> bool:
     if isinstance(value, int):
         if value in (0, 1):
             return bool(value)
-        raise ValueError(f"Invalid boolean integer '{value}'")
+        raise ValueError(f"Invalid boolean integer '{value}' for {env_name}")
     if isinstance(value, str):
         s = value.strip()
         if s == "":
@@ -38,8 +38,8 @@ def _coerce_bool(value: Any, default: bool) -> bool:
             return True
         if sl in FALSE_VALUES:
             return False
-        raise ValueError(f"Invalid boolean string '{value}'")
-    raise ValueError(f"Invalid boolean type '{type(value).__name__}'")
+        raise ValueError(f"Invalid boolean '{value}' for {env_name}")
+    raise ValueError(f"Invalid boolean type '{type(value).__name__}' for {env_name}")
 
 
 def _parse_int(value: Any, env_name: str, default: int) -> int:
@@ -88,7 +88,8 @@ class Settings(BaseSettings):
     @classmethod
     def _coerce_empty_bool(cls, v: Any, info) -> Any:  # type: ignore[override]
         default = cls.model_fields[info.field_name].default
-        return _coerce_bool(v, default)
+        env_name = info.field_name.upper()
+        return _coerce_bool(v, default, env_name)
 
     @field_validator("cg_top_n", "cg_days", mode="before")
     @classmethod

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -64,6 +64,8 @@ if isinstance(settings.log_level, str):
         )
 
 logging.basicConfig(level=lvl, format="%(message)s")
+for name in ("uvicorn", "uvicorn.error", "uvicorn.access"):
+    logging.getLogger(name).setLevel(lvl)
 
 logger.info(
     (

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -30,33 +30,34 @@ from .services.coingecko import CoinGeckoClient
 import logging
 
 
-LOG_LEVEL_NAMES = {"CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG", "NOTSET"}
+_NAME_MAP = {
+    **logging._nameToLevel,
+    "WARN": logging.WARNING,
+    "FATAL": logging.CRITICAL,
+}
 
 
-def parse_log_level(value: str | int | None) -> int:
-    """Return a valid logging level from various representations."""
+def parse_log_level(raw: str | int | None, default: int = logging.INFO) -> int:
+    """Parse log level names or integers, defaulting when unknown."""
 
-    default = logging.INFO
-    if value is None:
+    if raw is None:
         return default
-    if isinstance(value, int):
-        return value
-    s = str(value).strip()
-    if not s:
+    if isinstance(raw, int):
+        return raw
+    s = str(raw).strip().upper()
+    if s == "":
         return default
     if s.isdigit():
         return int(s)
-    up = s.upper()
-    mapping = {name: getattr(logging, name) for name in LOG_LEVEL_NAMES}
-    return mapping.get(up, default)
+    return _NAME_MAP.get(s, default)
 
 
 logger = logging.getLogger(__name__)
 
 lvl = parse_log_level(settings.log_level)
 if isinstance(settings.log_level, str):
-    s = settings.log_level.strip()
-    if s and not s.isdigit() and s.upper() not in LOG_LEVEL_NAMES:
+    s = settings.log_level.strip().upper()
+    if s and not s.isdigit() and s not in _NAME_MAP:
         logger.warning(
             "LOG_LEVEL=%r non reconnu, fallback sur %s",
             settings.log_level,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -29,8 +29,33 @@ from .services.coingecko import CoinGeckoClient
 
 import logging
 
-log_level = logging.getLevelName(settings.log_level.upper())
-logging.basicConfig(level=log_level, format="%(message)s")
+
+def parse_log_level(value: str | int | None) -> int:
+    """Return a valid logging level from various representations."""
+
+    default = logging.INFO
+    if value is None:
+        return default
+    if isinstance(value, int):
+        return value
+    s = str(value).strip()
+    if not s:
+        return default
+    if s.isdigit():
+        return int(s)
+    up = s.upper()
+    mapping = {
+        "CRITICAL": logging.CRITICAL,
+        "ERROR": logging.ERROR,
+        "WARNING": logging.WARNING,
+        "INFO": logging.INFO,
+        "DEBUG": logging.DEBUG,
+        "NOTSET": logging.NOTSET,
+    }
+    return mapping.get(up, default)
+
+
+logging.basicConfig(level=parse_log_level(settings.log_level), format="%(message)s")
 
 app = FastAPI(title="Tokenlysis")
 app.add_middleware(

--- a/backend/app/services/coingecko.py
+++ b/backend/app/services/coingecko.py
@@ -8,7 +8,7 @@ import time
 import requests
 
 from ..core.log import logger, request_id_ctx
-from ..core.settings import COINGECKO_API_KEY
+from ..core.settings import settings
 
 BASE_URL = "https://api.coingecko.com/api/v3"
 
@@ -27,7 +27,7 @@ class CoinGeckoClient:
     ) -> None:
         self.base_url = base_url.rstrip("/")
         self.session = session or requests.Session()
-        key = api_key or COINGECKO_API_KEY
+        key = api_key or settings.coingecko_api_key
         self.api_key = key
         if key:
             self.session.headers.update({"x-cg-pro-api-key": key})

--- a/tests/test_log_level.py
+++ b/tests/test_log_level.py
@@ -17,6 +17,7 @@ def test_basic_config_handles_blank():
         ("", logging.INFO),
         (" ", logging.INFO),
         ("debug", logging.DEBUG),
+        ("WARN", logging.WARNING),
         ("20", 20),
         ("INFO", logging.INFO),
         (" info ", logging.INFO),

--- a/tests/test_log_level.py
+++ b/tests/test_log_level.py
@@ -1,18 +1,27 @@
-from backend.app.main import parse_log_level
 import logging
 import pytest
 
+from backend.app.main import parse_log_level
 
-def test_parse_log_level_values():
-    assert parse_log_level(None) == logging.INFO
-    assert parse_log_level("") == logging.INFO
-    assert parse_log_level(" ") == logging.INFO
-    assert parse_log_level("debug") == logging.DEBUG
-    assert parse_log_level(" INFO ") == logging.INFO
-    assert parse_log_level(" info ") == logging.INFO
-    assert parse_log_level("20") == 20
-    assert parse_log_level("15") == 15
-    with pytest.raises(ValueError):
-        parse_log_level("foo")
-    with pytest.raises(ValueError):
-        parse_log_level("VERBOSE")
+
+def test_basic_config_handles_blank():
+    level = parse_log_level("")
+    assert level == logging.INFO
+    logging.basicConfig(level=level)
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (None, logging.INFO),
+        ("", logging.INFO),
+        (" ", logging.INFO),
+        ("debug", logging.DEBUG),
+        ("20", 20),
+        ("INFO", logging.INFO),
+        (" info ", logging.INFO),
+        ("foo", logging.INFO),
+    ],
+)
+def test_parse_log_level_various(value, expected):
+    assert parse_log_level(value) == expected

--- a/tests/test_log_level.py
+++ b/tests/test_log_level.py
@@ -10,4 +10,3 @@ def test_parse_log_level_values():
     assert parse_log_level(" INFO ") == logging.INFO
     assert parse_log_level("15") == 15
     assert parse_log_level("foo") == logging.INFO
-

--- a/tests/test_log_level.py
+++ b/tests/test_log_level.py
@@ -1,0 +1,13 @@
+from backend.app.main import parse_log_level
+import logging
+
+
+def test_parse_log_level_values():
+    assert parse_log_level(None) == logging.INFO
+    assert parse_log_level("") == logging.INFO
+    assert parse_log_level(" ") == logging.INFO
+    assert parse_log_level("debug") == logging.DEBUG
+    assert parse_log_level(" INFO ") == logging.INFO
+    assert parse_log_level("15") == 15
+    assert parse_log_level("foo") == logging.INFO
+

--- a/tests/test_log_level.py
+++ b/tests/test_log_level.py
@@ -1,5 +1,6 @@
 from backend.app.main import parse_log_level
 import logging
+import pytest
 
 
 def test_parse_log_level_values():
@@ -8,5 +9,10 @@ def test_parse_log_level_values():
     assert parse_log_level(" ") == logging.INFO
     assert parse_log_level("debug") == logging.DEBUG
     assert parse_log_level(" INFO ") == logging.INFO
+    assert parse_log_level(" info ") == logging.INFO
+    assert parse_log_level("20") == 20
     assert parse_log_level("15") == 15
-    assert parse_log_level("foo") == logging.INFO
+    with pytest.raises(ValueError):
+        parse_log_level("foo")
+    with pytest.raises(ValueError):
+        parse_log_level("VERBOSE")

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -67,5 +67,24 @@ def test_int_parsing(monkeypatch):
         settings_module.Settings()
 
 
+def test_log_level_parsing(monkeypatch):
+    monkeypatch.setenv("LOG_LEVEL", "")
+    cfg = settings_module.Settings()
+    assert cfg.log_level is None
+
+    monkeypatch.setenv("LOG_LEVEL", " INFO ")
+    cfg = settings_module.Settings()
+    assert cfg.log_level == "INFO"
+
+    monkeypatch.setenv("LOG_LEVEL", "15")
+    cfg = settings_module.Settings()
+    assert cfg.log_level == 15
+
+    monkeypatch.setenv("LOG_LEVEL", "maybe")
+    with pytest.raises(ValueError, match="Invalid LOG_LEVEL 'maybe'"):
+        settings_module.Settings()
+
+
 def test_mask_secret():
     assert settings_module.mask_secret("abcdef1234") == "******1234"
+

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,7 +1,6 @@
 import importlib
 import backend.app.core.settings as settings_module
 import pytest
-from pydantic import ValidationError
 
 
 def test_api_key_from_env(monkeypatch):
@@ -55,13 +54,10 @@ def test_use_seed_on_failure_false_variants(monkeypatch):
     assert cfg.use_seed_on_failure is False
 
 
-def test_invalid_bool(monkeypatch):
+def test_use_seed_on_failure_invalid_falls_back(monkeypatch):
     monkeypatch.setenv("USE_SEED_ON_FAILURE", "maybe")
-    with pytest.raises(
-        ValidationError,
-        match="Invalid boolean 'maybe' for USE_SEED_ON_FAILURE",
-    ):
-        settings_module.Settings()
+    cfg = settings_module.Settings()
+    assert cfg.use_seed_on_failure is False
 
 
 def test_int_parsing(monkeypatch):
@@ -102,6 +98,14 @@ def test_log_level_unknown_no_crash(monkeypatch):
     monkeypatch.setenv("LOG_LEVEL", "foo")
     cfg = settings_module.Settings()
     assert cfg.log_level == "FOO"
+
+
+def test_coerce_bool_helper():
+    from backend.app.core.settings import _coerce_bool
+
+    assert _coerce_bool("", False) is False
+    assert _coerce_bool(" YES ", False) is True
+    assert _coerce_bool("maybe", True) is True
 
 
 def test_mask_secret():

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -57,7 +57,10 @@ def test_use_seed_on_failure_false_variants(monkeypatch):
 
 def test_invalid_bool(monkeypatch):
     monkeypatch.setenv("USE_SEED_ON_FAILURE", "maybe")
-    with pytest.raises(ValidationError, match="Invalid boolean string"):
+    with pytest.raises(
+        ValidationError,
+        match="Invalid boolean 'maybe' for USE_SEED_ON_FAILURE",
+    ):
         settings_module.Settings()
 
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -74,6 +74,16 @@ def test_int_parsing(monkeypatch):
         settings_module.Settings()
 
 
+def test_cg_days_parsing(monkeypatch):
+    monkeypatch.setenv("CG_DAYS", "")
+    cfg = settings_module.Settings()
+    assert cfg.cg_days == 14
+
+    monkeypatch.setenv("CG_DAYS", "abc")
+    with pytest.raises(ValueError, match="Invalid integer 'abc' for CG_DAYS"):
+        settings_module.Settings()
+
+
 def test_log_level_parsing(monkeypatch):
     monkeypatch.setenv("LOG_LEVEL", "")
     cfg = settings_module.Settings()
@@ -86,6 +96,12 @@ def test_log_level_parsing(monkeypatch):
     monkeypatch.setenv("LOG_LEVEL", "15")
     cfg = settings_module.Settings()
     assert cfg.log_level == 15
+
+
+def test_log_level_unknown_no_crash(monkeypatch):
+    monkeypatch.setenv("LOG_LEVEL", "foo")
+    cfg = settings_module.Settings()
+    assert cfg.log_level == "FOO"
 
 
 def test_mask_secret():


### PR DESCRIPTION
## Summary
- make log level parsing resilient to blanks and unknown values
- normalize and validate numeric, boolean, and log level environment variables
- document avoiding empty env vars in examples and deployment notes

## Testing
- `ruff check backend`
- `black backend`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd855e19c08327843262e871f2a2ad