### PR TITLE
fix: handle CoinGecko auth and add basic markets endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ Runtime behaviour can be tweaked with environment variables:
   `http://localhost`)
 - `CG_TOP_N` – number of assets fetched from CoinGecko (default: `20`)
 - `CG_DAYS` – number of days of history to retrieve (default: `14`)
-- `COINGECKO_API_KEY` – optional API key for the CoinGecko Pro plan
+- `COINGECKO_API_KEY` – optional API key for CoinGecko
+- `COINGECKO_PLAN` – `demo` (default) or `pro` to select the API header
 - `USE_SEED_ON_FAILURE` – fall back to bundled seed data when live ETL fails (default: `false`)
 - `LOG_LEVEL` – base logging level for application and Uvicorn loggers (default: `INFO`).
   Accepts an integer or one of
@@ -132,7 +133,8 @@ seed assets (`C1`, `C2`, …) are mapped to real CoinGecko IDs through
 ### Health & Diagnostics
 
 - `GET /healthz` – basic liveness probe
-- `GET /readyz` – readiness check querying CoinGecko
+- `GET /readyz` – readiness check for the web process
+- `GET /api/markets/basic` – minimal market data fallback
 - `GET /api/diag` – returns app version, outbound status and masked API key
 
 ### Synology NAS Deployment (POC)

--- a/backend/app/services/coingecko.py
+++ b/backend/app/services/coingecko.py
@@ -1,16 +1,16 @@
 import json
 import logging
+import random
 import time
 from typing import List
 
 import requests
 
-from ..core.settings import settings
+from ..core.settings import settings, mask_secret
 
 logger = logging.getLogger(__name__)
 
-PRO_BASE = "https://pro-api.coingecko.com/api/v3"
-PUB_BASE = "https://api.coingecko.com/api/v3"
+BASE_URL = "https://api.coingecko.com/api/v3"
 
 
 class CoinGeckoClient:
@@ -18,23 +18,27 @@ class CoinGeckoClient:
 
     def __init__(
         self,
-        base_url: str,
         api_key: str | None,
+        plan: str = "demo",
+        base_url: str = BASE_URL,
         session: requests.Session | None = None,
     ) -> None:
         self.base_url = base_url.rstrip("/")
         self.session = session or requests.Session()
         self.session.headers.update(
-            {"Accept": "application/json", "User-Agent": "tokenlysis/1.0"}
+            {"Accept": "application/json", "User-Agent": "Tokenlysis/1.0"}
         )
         if api_key:
-            self.session.headers.update({"x-cg-pro-api-key": api_key})
+            header_name = "x-cg-pro-api-key" if plan == "pro" else "x-cg-demo-api-key"
+            self.session.headers.update({header_name: api_key})
+            masked = mask_secret(api_key)
+            logger.info("CoinGecko auth header set: %s=%s", header_name, masked)
         self.api_key = api_key
 
     def _request(self, path: str, params: dict | None = None) -> requests.Response:
         url = f"{self.base_url}{path}"
         time.sleep(settings.CG_THROTTLE_MS / 1000.0)
-        for attempt in range(1, 6):
+        for attempt in range(6):
             t0 = time.perf_counter()
             resp = self.session.get(url, params=params, timeout=(3.1, 20))
             latency = int((time.perf_counter() - t0) * 1000)
@@ -52,11 +56,25 @@ class CoinGeckoClient:
             )
             if resp.status_code == 429:
                 ra = resp.headers.get("Retry-After")
-                sleep_s = float(ra) if ra else min(2**attempt, 16)
-                time.sleep(sleep_s)
+                if ra:
+                    wait = float(ra)
+                else:
+                    wait = min(0.5 * (2**attempt), 8)
+                    wait += random.uniform(0, 0.1)
+                time.sleep(wait)
                 continue
-            resp.raise_for_status()
-            return resp
+            try:
+                resp.raise_for_status()
+                return resp
+            except requests.HTTPError:
+                logger.error(
+                    "CG error %s %s params=%s body=%s",
+                    resp.status_code,
+                    url,
+                    params,
+                    resp.text[:500],
+                )
+                raise
         resp.raise_for_status()
         return resp
 
@@ -71,14 +89,16 @@ class CoinGeckoClient:
         self,
         vs: str = "usd",
         order: str = "market_cap_desc",
-        per_page: int = 100,
+        per_page: int = 20,
         page: int = 1,
     ) -> List[dict]:
         params = {"vs_currency": vs, "order": order, "per_page": per_page, "page": page}
         return self._request("/coins/markets", params).json()
 
     def get_market_chart(
-        self, coin_id: str, days: int, vs: str = "usd", interval: str | None = None
+        self, coin_id: str, days: int, vs: str = "usd", interval: str | None = "daily"
     ) -> dict:
-        params = {"vs_currency": vs, "days": days, "interval": interval or "daily"}
+        params = {"vs_currency": vs, "days": days}
+        if interval:
+            params["interval"] = interval
         return self._request(f"/coins/{coin_id.lower()}/market_chart", params).json()

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,6 +9,7 @@
     table { border-collapse: collapse; width: 100%; }
     th, td { border: 1px solid #ccc; padding: 8px; text-align: left; }
     th { background-color: #f2f2f2; }
+    .badge { background-color: #eee; padding: 2px 4px; border-radius: 3px; margin-left: 4px; font-size: 0.8em; }
     #status { margin: 10px 0; }
     #diag { margin-top: 20px; font-size: 0.9em; color: #555; }
   </style>
@@ -19,10 +20,10 @@
   <table id="cryptos" style="display:none;">
     <thead>
       <tr>
-        <th>Symbol</th>
         <th>Name</th>
+        <th>Symbol</th>
         <th>Price (USD)</th>
-        <th>Score Global</th>
+        <th>Score</th>
       </tr>
     </thead>
     <tbody></tbody>
@@ -45,19 +46,52 @@
         const res = await fetch(url);
         const latency = Math.round(performance.now() - start);
         lastRequest = { url, status: res.status, latency };
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        if (!res.ok) {
+          if (res.status === 503) {
+            await loadBasic();
+            return;
+          }
+          throw new Error(`HTTP ${res.status}`);
+        }
         const data = await res.json();
         if (!data.items.length) {
           statusEl.textContent = 'No crypto';
         } else {
           data.items.forEach(item => {
             const tr = document.createElement('tr');
-            tr.innerHTML = `<td>${item.symbol}</td><td>${item.name}</td><td>${item.latest.price_usd}</td><td>${item.latest.scores.global}</td>`;
+            tr.innerHTML = `<td>${item.name}</td><td>${item.symbol}</td><td>${item.latest.price_usd}</td><td>${item.latest.scores.global}</td>`;
             tbody.appendChild(tr);
           });
           statusEl.textContent = '';
           document.getElementById('cryptos').style.display = 'table';
         }
+      } catch (err) {
+        statusEl.innerHTML = `Error fetching data <button id="retry">Retry</button>`;
+        document.getElementById('retry').onclick = loadCryptos;
+        console.error(err);
+      }
+      loadDiag();
+    }
+
+    async function loadBasic() {
+      const statusEl = document.getElementById('status');
+      const tbody = document.querySelector('#cryptos tbody');
+      tbody.innerHTML = '';
+      const url = `${API_URL}/markets/basic?limit=20`;
+      const start = performance.now();
+      try {
+        const res = await fetch(url);
+        const latency = Math.round(performance.now() - start);
+        lastRequest = { url, status: res.status, latency };
+        const data = await res.json();
+        data.items.forEach(item => {
+          const tr = document.createElement('tr');
+          tr.innerHTML = `<td>${item.name}</td><td>${item.symbol}</td><td>${item.price}</td><td>${item.score} <span class="badge">demo</span></td>`;
+          tbody.appendChild(tr);
+        });
+        document.getElementById('cryptos').style.display = 'table';
+        statusEl.innerHTML = `données minimales (ETL indisponible) <button id="retry">Réessayer</button>`;
+        document.getElementById('retry').onclick = loadCryptos;
       } catch (err) {
         statusEl.innerHTML = `Error fetching data <button id="retry">Retry</button>`;
         document.getElementById('retry').onclick = loadCryptos;

--- a/tests/test_markets_basic.py
+++ b/tests/test_markets_basic.py
@@ -1,0 +1,18 @@
+from types import SimpleNamespace
+
+import backend.app.main as main_module
+
+
+def test_markets_basic_endpoint():
+    class DummyClient:
+        def get_markets(self, vs="usd", per_page=20, page=1, order="market_cap_desc"):
+            return [{"name": "Bitcoin", "symbol": "btc", "current_price": 123}]
+
+    req = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(cg_client=DummyClient())))
+    resp = main_module.markets_basic(request=req, limit=1)
+    assert resp["count"] == 1
+    item = resp["items"][0]
+    assert item["name"] == "Bitcoin"
+    assert item["symbol"] == "BTC"
+    assert item["price"] == 123
+    assert item["score"] == 0

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -6,18 +6,17 @@ import backend.app.core.settings as settings_module
 
 def test_api_key_from_env(monkeypatch):
     monkeypatch.setenv("COINGECKO_API_KEY", "env-key")
+    monkeypatch.delenv("COINGECKO_PLAN", raising=False)
     importlib.reload(settings_module)
     assert settings_module.settings.COINGECKO_API_KEY == "env-key"
-    assert settings_module.get_coingecko_headers() == {"x-cg-pro-api-key": "env-key"}
-    assert (
-        settings_module.effective_coingecko_base_url()
-        == "https://pro-api.coingecko.com/api/v3"
-    )
+    assert settings_module.get_coingecko_headers() == {"x-cg-demo-api-key": "env-key"}
+    assert settings_module.effective_coingecko_base_url() == "https://api.coingecko.com/api/v3"
 
 
 def test_lowercase_api_key(monkeypatch):
     monkeypatch.delenv("COINGECKO_API_KEY", raising=False)
     monkeypatch.setenv("coingecko_api_key", "low-key")
+    monkeypatch.setenv("COINGECKO_PLAN", "pro")
     importlib.reload(settings_module)
     assert settings_module.settings.coingecko_api_key == "low-key"
     assert settings_module.get_coingecko_headers() == {"x-cg-pro-api-key": "low-key"}


### PR DESCRIPTION
## Summary
- ensure CoinGecko requests use API key headers for demo/pro plans
- add resilient ETL and basic markets fallback endpoint
- provide frontend fallback when ranking data is unavailable

## Testing
- `ruff check backend && black backend`
- `pytest`
- `curl -i -H "x-cg-demo-api-key: demo" https://api.coingecko.com/api/v3/ping` *(fails: 403 Forbidden)*
- `curl -i -H "x-cg-demo-api-key: demo" "https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&order=market_cap_desc&per_page=20&page=1"` *(fails: 403 Forbidden)*
- `curl -s -i -H "x-cg-demo-api-key: demo" "https://api.coingecko.com/api/v3/coins/bitcoin/market_chart?vs_currency=usd&days=14&interval=daily"` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bda2226ec88327a71964f0cb82c337