### PR TITLE
feat: add demo markets fallback and diagnostics

### DIFF
--- a/backend/app/core/settings.py
+++ b/backend/app/core/settings.py
@@ -149,8 +149,7 @@ def get_coingecko_headers() -> dict[str, str]:
 
 def effective_coingecko_base_url() -> str:
     """Return the CoinGecko base URL for the configured plan."""
-    key = settings.COINGECKO_API_KEY or settings.coingecko_api_key
-    if key and settings.COINGECKO_PLAN in {"demo", "pro"}:
+    if settings.COINGECKO_PLAN == "pro":
         return "https://pro-api.coingecko.com/api/v3"
     return "https://api.coingecko.com/api/v3"
 

--- a/backend/app/etl/run.py
+++ b/backend/app/etl/run.py
@@ -53,9 +53,7 @@ def _coin_history(coin: dict, days: int, client: CoinGeckoClient) -> dict:
         or SEED_TO_COINGECKO.get(coin.get("symbol", ""))
         or coin.get("id")
     )
-    return client.get_market_chart(
-        coin_id, days, vs="usd", interval=settings.CG_INTERVAL
-    )
+    return client.get_market_chart(coin_id, days, vs="usd")
 
 
 def _coingecko_etl(limit: int, days: int, client: CoinGeckoClient) -> Dict[int, Dict]:

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -34,6 +34,13 @@
     const API_URL = document.querySelector('meta[name="api-url"]')?.content || '';
     let lastRequest = {};
 
+    function formatPrice(p) {
+      if (p === null || p === undefined) return '';
+      if (p >= 1) return p.toFixed(2);
+      if (p >= 0.01) return p.toFixed(4);
+      return p.toFixed(6);
+    }
+
     async function loadCryptos() {
       const statusEl = document.getElementById('status');
       statusEl.textContent = 'Loading...';
@@ -47,7 +54,7 @@
         const latency = Math.round(performance.now() - start);
         lastRequest = { url, status: res.status, latency };
         if (!res.ok) {
-          if (res.status === 503) {
+          if ([503, 500, 429, 400].includes(res.status)) {
             await loadBasic();
             return;
           }
@@ -59,7 +66,7 @@
         } else {
           data.items.forEach(item => {
             const tr = document.createElement('tr');
-            tr.innerHTML = `<td>${item.name}</td><td>${item.symbol}</td><td>${item.latest.price_usd}</td><td>${item.latest.scores.global}</td>`;
+            tr.innerHTML = `<td>${item.name}</td><td>${item.symbol}</td><td>${formatPrice(item.latest.price_usd)}</td><td>${item.latest.scores.global}</td>`;
             tbody.appendChild(tr);
           });
           statusEl.textContent = '';
@@ -86,7 +93,8 @@
         const data = await res.json();
         data.items.forEach(item => {
           const tr = document.createElement('tr');
-          tr.innerHTML = `<td>${item.name}</td><td>${item.symbol}</td><td>${item.price}</td><td>${item.score} <span class="badge">demo</span></td>`;
+          const badge = data.demo ? ' <span class="badge">DEMO</span>' : '';
+          tr.innerHTML = `<td>${item.name}</td><td>${item.symbol}</td><td>${formatPrice(item.price)}</td><td>${item.score}${badge}</td>`;
           tbody.appendChild(tr);
         });
         document.getElementById('cryptos').style.display = 'table';
@@ -115,7 +123,7 @@
       try {
         const res = await fetch(`${API_URL}/diag`);
         const data = await res.json();
-        const diag = `URL: ${lastRequest.url || ''} (${lastRequest.status || ''} in ${lastRequest.latency || 0}ms) | outbound_ok: ${data.outbound_ok} | coingecko_ping: ${data.coingecko_ping} | api_key: ${data.api_key_masked || 'none'}`;
+        const diag = `URL: ${lastRequest.url || ''} (${lastRequest.status || ''} in ${lastRequest.latency || 0}ms) | plan: ${data.plan} | has_key: ${data.has_api_key} | base: ${data.base_url} | interval: ${data.interval_policy}`;
         document.getElementById('diag').textContent = diag;
       } catch (err) {
         document.getElementById('diag').textContent = 'Diag unavailable';

--- a/tests/test_etl.py
+++ b/tests/test_etl.py
@@ -12,14 +12,8 @@ class DummyClient:
     def __init__(self) -> None:
         self.called_with = None
 
-    def get_market_chart(
-        self,
-        coin_id: str,
-        days: int,
-        vs: str = "usd",
-        interval: str | None = None,
-    ):
-        self.called_with = (coin_id, days, vs, interval)
+    def get_market_chart(self, coin_id: str, days: int, vs: str = "usd"):
+        self.called_with = (coin_id, days, vs)
         return {"prices": []}
 
 
@@ -27,24 +21,14 @@ def test_coin_history_uses_coingecko_id():
     coin = {"coingecko_id": "bitcoin", "symbol": "btc", "id": "btc"}
     client = DummyClient()
     _coin_history(coin, 14, client)
-    assert client.called_with == (
-        "bitcoin",
-        14,
-        "usd",
-        settings_module.settings.CG_INTERVAL,
-    )
+    assert client.called_with == ("bitcoin", 14, "usd")
 
 
 def test_coin_history_maps_seed_symbol():
     coin = {"symbol": "C1", "id": "1"}
     client = DummyClient()
     _coin_history(coin, 14, client)
-    assert client.called_with == (
-        "bitcoin",
-        14,
-        "usd",
-        settings_module.settings.CG_INTERVAL,
-    )
+    assert client.called_with == ("bitcoin", 14, "usd")
 
 
 def _boom(*args, **kwargs):  # helper for failing ETL

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -12,7 +12,7 @@ def test_api_key_from_env(monkeypatch):
     assert settings_module.get_coingecko_headers() == {"x-cg-demo-api-key": "env-key"}
     assert (
         settings_module.effective_coingecko_base_url()
-        == "https://pro-api.coingecko.com/api/v3"
+        == "https://api.coingecko.com/api/v3"
     )
 
 

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -26,10 +26,9 @@ def test_diag_masks_key(monkeypatch):
     import backend.app.main as main_module
 
     reload(main_module)
-    monkeypatch.setattr(main_module.CoinGeckoClient, "ping", lambda self: "pong")
     client = TestClient(main_module.app)
     resp = client.get("/api/diag")
     assert resp.status_code == 200
     data = resp.json()
-    assert data["api_key_masked"].endswith("1234")
+    assert data["has_api_key"] is True
     assert "supersecret1234" not in resp.text


### PR DESCRIPTION
## Summary
- log CoinGecko requests with plan and demo header
- serve minimal markets data when ranking fails
- expose new diagnostics and readiness info

## Testing
- `ruff check backend && black backend`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bda6e54af88327be2a0934f3765439