### PR TITLE
fix: support CoinGecko demo plan

### DIFF
--- a/backend/app/core/settings.py
+++ b/backend/app/core/settings.py
@@ -67,7 +67,7 @@ class Settings(BaseSettings):
     COINGECKO_API_KEY: str | None = None
     coingecko_api_key: str | None = Field(default=None, alias="coingecko_api_key")
     COINGECKO_PLAN: str = "demo"
-    CG_TOP_N: int = 100
+    CG_TOP_N: int = 50
     CG_DAYS: int = 14
     CG_INTERVAL: str | None = "daily"
     CG_THROTTLE_MS: int = 150

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -16,6 +16,7 @@
 </head>
 <body>
   <h1>Tokenlysis Cryptos</h1>
+  <div id="demo-banner" style="display:none;background:#fffae6;padding:6px;margin-bottom:10px;">mode demo : indicateurs avancés désactivés</div>
   <div id="status">Loading...</div>
   <table id="cryptos" style="display:none;">
     <thead>
@@ -54,24 +55,22 @@
         const latency = Math.round(performance.now() - start);
         lastRequest = { url, status: res.status, latency };
         if (!res.ok) {
-          if ([503, 500, 429, 400].includes(res.status)) {
-            await loadBasic();
-            return;
-          }
-          throw new Error(`HTTP ${res.status}`);
+          await loadMarkets();
+          return;
         }
         const data = await res.json();
         if (!data.items.length) {
-          statusEl.textContent = 'No crypto';
-        } else {
-          data.items.forEach(item => {
-            const tr = document.createElement('tr');
-            tr.innerHTML = `<td>${item.name}</td><td>${item.symbol}</td><td>${formatPrice(item.latest.price_usd)}</td><td>${item.latest.scores.global}</td>`;
-            tbody.appendChild(tr);
-          });
-          statusEl.textContent = '';
-          document.getElementById('cryptos').style.display = 'table';
+          await loadMarkets();
+          return;
         }
+        data.items.forEach(item => {
+          const tr = document.createElement('tr');
+          tr.innerHTML = `<td>${item.name}</td><td>${item.symbol}</td><td>${formatPrice(item.latest.price_usd)}</td><td>${item.latest.scores.global}</td>`;
+          tbody.appendChild(tr);
+        });
+        statusEl.textContent = '';
+        document.getElementById('cryptos').style.display = 'table';
+        document.getElementById('demo-banner').style.display = 'none';
       } catch (err) {
         statusEl.innerHTML = `Error fetching data <button id="retry">Retry</button>`;
         document.getElementById('retry').onclick = loadCryptos;
@@ -80,26 +79,26 @@
       loadDiag();
     }
 
-    async function loadBasic() {
+    async function loadMarkets() {
       const statusEl = document.getElementById('status');
       const tbody = document.querySelector('#cryptos tbody');
       tbody.innerHTML = '';
-      const url = `${API_URL}/markets/basic?limit=20`;
+      const url = `${API_URL}/markets?limit=20`;
       const start = performance.now();
       try {
         const res = await fetch(url);
         const latency = Math.round(performance.now() - start);
         lastRequest = { url, status: res.status, latency };
         const data = await res.json();
-        data.items.forEach(item => {
+        data.forEach(item => {
           const tr = document.createElement('tr');
-          const badge = data.demo ? ' <span class="badge">DEMO</span>' : '';
-          tr.innerHTML = `<td>${item.name}</td><td>${item.symbol}</td><td>${formatPrice(item.price)}</td><td>${item.score}${badge}</td>`;
+          tr.innerHTML = `<td>${item.name}</td><td>${item.symbol}</td><td>${formatPrice(item.price)}</td><td>${item.score}</td>`;
           tbody.appendChild(tr);
         });
         document.getElementById('cryptos').style.display = 'table';
         statusEl.innerHTML = `données minimales (ETL indisponible) <button id="retry">Réessayer</button>`;
         document.getElementById('retry').onclick = loadCryptos;
+        document.getElementById('demo-banner').style.display = 'block';
       } catch (err) {
         statusEl.innerHTML = `Error fetching data <button id="retry">Retry</button>`;
         document.getElementById('retry').onclick = loadCryptos;
@@ -123,7 +122,7 @@
       try {
         const res = await fetch(`${API_URL}/diag`);
         const data = await res.json();
-        const diag = `URL: ${lastRequest.url || ''} (${lastRequest.status || ''} in ${lastRequest.latency || 0}ms) | plan: ${data.plan} | has_key: ${data.has_api_key} | base: ${data.base_url} | interval: ${data.interval_policy}`;
+        const diag = `URL: ${lastRequest.url || ''} (${lastRequest.status || ''} in ${lastRequest.latency || 0}ms) | plan=${data.plan} | granularity=${data.granularity} | last_etl_items=${data.last_etl_items}`;
         document.getElementById('diag').textContent = diag;
       } catch (err) {
         document.getElementById('diag').textContent = 'Diag unavailable';

--- a/tests/test_etl.py
+++ b/tests/test_etl.py
@@ -53,3 +53,11 @@ def test_run_etl_raises_when_disabled(monkeypatch):
     dummy = SimpleNamespace(api_key=None)
     with pytest.raises(run_module.DataUnavailable):
         run_module.run_etl(dummy)
+
+
+def test_to_daily_close():
+    pairs = [[0, 1.0], [1000 * 60 * 60 * 23, 2.0], [1000 * 60 * 60 * 25, 3.0]]
+    result = run_module.to_daily_close(pairs)
+    assert len(result) == 2
+    assert result[0][1] == 2.0
+    assert result[1][1] == 3.0

--- a/tests/test_markets.py
+++ b/tests/test_markets.py
@@ -3,16 +3,16 @@ from types import SimpleNamespace
 import backend.app.main as main_module
 
 
-def test_markets_basic_endpoint():
+def test_markets_endpoint():
     class DummyClient:
         def get_markets(self, vs="usd", per_page=20, page=1, order="market_cap_desc"):
             return [{"name": "Bitcoin", "symbol": "btc", "current_price": 123}]
 
     req = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(cg_client=DummyClient())))
-    resp = main_module.markets_basic(request=req, limit=1)
-    assert resp["count"] == 1
-    item = resp["items"][0]
+    resp = main_module.markets(request=req, limit=1)
+    assert len(resp) == 1
+    item = resp[0]
     assert item["name"] == "Bitcoin"
     assert item["symbol"] == "BTC"
     assert item["price"] == 123
-    assert item["score"] == 0
+    assert item["score"] == 0.0

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -89,7 +89,7 @@ def test_use_seed_on_failure_invalid_falls_back(monkeypatch):
 def test_int_parsing(monkeypatch):
     monkeypatch.setenv("CG_TOP_N", "")
     cfg = settings_module.Settings()
-    assert cfg.CG_TOP_N == 100
+    assert cfg.CG_TOP_N == 50
 
     monkeypatch.setenv("CG_TOP_N", "abc")
     with pytest.raises(ValueError, match="Invalid integer 'abc' for CG_TOP_N"):


### PR DESCRIPTION
## Summary
- handle CoinGecko demo authentication and retry logic
- resample hourly data to daily and keep coins when history fails
- add `/api/markets` fallback and demo banner on frontend

## Testing
- `ruff check backend`
- `black backend`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bdadb41e90832781276ea8478c4369