### PR TITLE
feat: surface build version from CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,13 @@
-name: Build images with commit version
+name: Build images with run number version
 
 on:
   push:
-    branches: [ main ]        # adapter si besoin
+    branches: [ main ]
   pull_request:
     branches: [ main ]
+
+env:
+  APP_VERSION: 1.0.${{ github.run_number }}
 
 jobs:
   build:
@@ -16,10 +19,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Compute version from commit count
-        run: |
-          echo "APP_VERSION=$(git rev-list --count HEAD)" >> $GITHUB_ENV
-          echo "GIT_COMMIT=${GITHUB_SHA}" >> $GITHUB_ENV
+      - name: Export commit SHA
+        run: echo "GIT_COMMIT=${GITHUB_SHA}" >> $GITHUB_ENV
+
+      - name: Show computed version
+        run: echo "APP_VERSION=${APP_VERSION}"
 
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v3

--- a/README.md
+++ b/README.md
@@ -205,8 +205,8 @@ build argument and is exposed inside the container as the `APP_VERSION`
 environment variable. The same value is also written to the
 `org.opencontainers.image.version` OCI label for traceability.
 
-GitHub Actions computes the value with `git rev-list --count HEAD` and injects it
-with `--build-arg APP_VERSION=${APP_VERSION_SHORT}` during the build. When
+GitHub Actions sets the value to `1.0.<run_number>` using `github.run_number` and
+injects it with `--build-arg APP_VERSION=${APP_VERSION}` during the build. When
 building locally you can override the version:
 
 ```bash

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -84,6 +84,8 @@ logger.info(
     mask_secret(settings.COINGECKO_API_KEY),
 )
 
+logger.info("App version: %s", get_version())
+
 app = FastAPI(title="Tokenlysis")
 app.add_middleware(
     CORSMiddleware,

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -31,6 +31,7 @@
   </table>
   <div id="version"></div>
   <div id="diag"></div>
+  <script type="module" src="version.js"></script>
   <script>
     const API_URL = document.querySelector('meta[name="api-url"]')?.content || '';
     let lastRequest = {};
@@ -108,12 +109,17 @@
     }
 
     async function loadVersion() {
+      const local = getAppVersion();
+      if (local && local !== 'dev') {
+        document.getElementById('version').textContent = `Version: ${local}`;
+        return;
+      }
       try {
         const res = await fetch(`${API_URL}/version`);
         const data = await res.json();
         document.getElementById('version').textContent = `Version: ${data.version}`;
       } catch (err) {
-        document.getElementById('version').textContent = 'Version: unknown';
+        document.getElementById('version').textContent = 'Version: dev';
         console.error(err);
       }
     }

--- a/frontend/version.js
+++ b/frontend/version.js
@@ -1,0 +1,28 @@
+export function getAppVersion() {
+  try {
+    if (
+      typeof import !== 'undefined' &&
+      typeof import.meta !== 'undefined' &&
+      (import.meta).env &&
+      (import.meta).env.VITE_APP_VERSION
+    ) {
+      return (import.meta).env.VITE_APP_VERSION;
+    }
+  } catch (_) {
+    // ignored
+  }
+  if (typeof process !== 'undefined') {
+    if (process.env && process.env.NEXT_PUBLIC_APP_VERSION) {
+      return process.env.NEXT_PUBLIC_APP_VERSION;
+    }
+    if (process.env && process.env.APP_VERSION) {
+      return process.env.APP_VERSION;
+    }
+  }
+  return 'dev';
+}
+
+if (typeof window !== 'undefined') {
+  // Expose for inline scripts
+  window.getAppVersion = getAppVersion;
+}


### PR DESCRIPTION
## Summary
- log application version at startup
- display computed version in UI
- derive build version from GitHub run number

## Testing
- `ruff check backend`
- `black backend`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bdc809c0a083278846b3d91220a843