### PR TITLE
fix: expose build version in static frontend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,13 @@ ENV APP_VERSION=$APP_VERSION
 
 WORKDIR /app
 
-RUN echo "${APP_VERSION}" > VERSION
 COPY backend/requirements.txt ./
 RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/* \
     && pip install --no-cache-dir -r requirements.txt
 COPY backend ./backend
 COPY frontend ./frontend
+RUN echo "${APP_VERSION}" > VERSION \
+    && echo "window.APP_VERSION='${APP_VERSION}';" > frontend/app-version.js
 
 EXPOSE 8000
 CMD ["uvicorn", "backend.app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -216,6 +216,10 @@ docker build --build-arg APP_VERSION=42 -t tokenlysis:test -f ./Dockerfile .
 At runtime the container exposes `APP_VERSION` so it can be inspected with
 `docker run --rm tokenlysis:test env | grep APP_VERSION`.
 
+During the build the same value is also written to `frontend/app-version.js`
+so the static dashboard can display the version even if the API is
+unreachable.
+
 ## License
 
 This project is licensed under the MIT License.

--- a/frontend/app-version.js
+++ b/frontend/app-version.js
@@ -1,0 +1,2 @@
+window.APP_VERSION = 'dev';
+

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -31,6 +31,7 @@
   </table>
   <div id="version"></div>
   <div id="diag"></div>
+  <script src="./app-version.js"></script>
   <script type="module">
     import { getAppVersion } from './version.js';
 

--- a/frontend/version.js
+++ b/frontend/version.js
@@ -14,6 +14,9 @@ export function getAppVersion() {
       return process.env.APP_VERSION;
     }
   }
+  if (typeof window !== 'undefined' && window.APP_VERSION) {
+    return window.APP_VERSION;
+  }
   return 'dev';
 }
 


### PR DESCRIPTION
## Summary
- embed build version into `frontend/app-version.js` and load it on the dashboard
- document that the frontend now receives the image version at build time

## Testing
- `ruff check backend`
- `black backend`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bdd076d34883279b12455ed4d9c920