### PR TITLE
feat: add readiness probe and static frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ seed assets (`C1`, `C2`, …) are mapped to real CoinGecko IDs through
 ### Health & Diagnostics
 
 - `GET /healthz` – basic liveness probe
-- `GET /readyz` – readiness check for the web process
+- `GET /readyz` – readiness check for the web process (`{"ready": true}`)
 - `GET /api/markets/basic` – minimal market data fallback
 - `GET /api/diag` – returns app version, outbound status and masked API key
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -51,42 +51,7 @@
       document.getElementById('cryptos').style.display = 'none';
       const tbody = document.querySelector('#cryptos tbody');
       tbody.innerHTML = '';
-      const url = `${API_URL}/ranking?limit=20`;
-      const start = performance.now();
-      try {
-        const res = await fetch(url);
-        const latency = Math.round(performance.now() - start);
-        lastRequest = { url, status: res.status, latency };
-        if (!res.ok) {
-          await loadMarkets();
-          return;
-        }
-        const data = await res.json();
-        if (!data.items.length) {
-          await loadMarkets();
-          return;
-        }
-        data.items.forEach(item => {
-          const tr = document.createElement('tr');
-          tr.innerHTML = `<td>${item.name}</td><td>${item.symbol}</td><td>${formatPrice(item.latest.price_usd)}</td><td>${item.latest.scores.global}</td>`;
-          tbody.appendChild(tr);
-        });
-        statusEl.textContent = '';
-        document.getElementById('cryptos').style.display = 'table';
-        document.getElementById('demo-banner').style.display = 'none';
-      } catch (err) {
-        statusEl.innerHTML = `Error fetching data <button id="retry">Retry</button>`;
-        document.getElementById('retry').onclick = loadCryptos;
-        console.error(err);
-      }
-      loadDiag();
-    }
-
-    async function loadMarkets() {
-      const statusEl = document.getElementById('status');
-      const tbody = document.querySelector('#cryptos tbody');
-      tbody.innerHTML = '';
-      const url = `${API_URL}/markets?limit=20`;
+      const url = `${API_URL}/markets/top?limit=20&vs=usd`;
       const start = performance.now();
       try {
         const res = await fetch(url);
@@ -99,8 +64,7 @@
           tbody.appendChild(tr);
         });
         document.getElementById('cryptos').style.display = 'table';
-        statusEl.innerHTML = `données minimales (ETL indisponible) <button id="retry">Réessayer</button>`;
-        document.getElementById('retry').onclick = loadCryptos;
+        statusEl.textContent = '';
         document.getElementById('demo-banner').style.display = 'block';
       } catch (err) {
         statusEl.innerHTML = `Error fetching data <button id="retry">Retry</button>`;

--- a/tests/test_frontend_routes.py
+++ b/tests/test_frontend_routes.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+
+def test_frontend_fetches_markets_top():
+    html = Path("frontend/index.html").read_text()
+    assert "/markets/top?limit=20&vs=usd" in html
+    assert "/markets?" not in html.replace("/markets/top?limit=20&vs=usd", "")
+
+
+def test_frontend_no_ranking_call():
+    html = Path("frontend/index.html").read_text()
+    assert "/ranking" not in html
+
+
+def test_frontend_version_scripts_present():
+    html = Path("frontend/index.html").read_text()
+    assert '<script src="./app-version.js"></script>' in html
+    assert "import { getAppVersion } from './version.js';" in html

--- a/tests/test_readyz.py
+++ b/tests/test_readyz.py
@@ -1,0 +1,76 @@
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend.app.db import Base, get_session
+
+
+def _setup_test_session(tmp_path):
+    engine = create_engine(
+        f"sqlite:///{tmp_path/'test.db'}", connect_args={"check_same_thread": False}
+    )
+    TestingSessionLocal = sessionmaker(
+        bind=engine, autoflush=False, autocommit=False, expire_on_commit=False
+    )
+    Base.metadata.create_all(bind=engine)
+    return TestingSessionLocal
+
+
+def test_readyz_ok(monkeypatch, tmp_path):
+    TestingSessionLocal = _setup_test_session(tmp_path)
+
+    import backend.app.main as main_module
+
+    main_module.app.dependency_overrides[get_session] = lambda: TestingSessionLocal()
+    client = TestClient(main_module.app)
+
+    resp = client.get("/readyz")
+    assert resp.status_code == 200
+    assert resp.json() == {"ready": True}
+
+
+def test_readyz_db_error(monkeypatch, tmp_path):
+    class BrokenSession:
+        def execute(self, *_a, **_k):
+            raise RuntimeError("boom")
+
+        def close(self):
+            pass
+
+    def _broken_session():
+        session = BrokenSession()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    import backend.app.main as main_module
+
+    main_module.app.dependency_overrides[get_session] = _broken_session
+    client = TestClient(main_module.app)
+
+    resp = client.get("/readyz")
+    assert resp.status_code == 503
+
+
+def test_frontend_served(monkeypatch, tmp_path):
+    TestingSessionLocal = _setup_test_session(tmp_path)
+    import backend.app.main as main_module
+
+    main_module.app.dependency_overrides[get_session] = lambda: TestingSessionLocal()
+    client = TestClient(main_module.app)
+
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert "<!DOCTYPE html>" in resp.text
+
+
+def test_frontend_missing_file(monkeypatch, tmp_path):
+    TestingSessionLocal = _setup_test_session(tmp_path)
+    import backend.app.main as main_module
+
+    main_module.app.dependency_overrides[get_session] = lambda: TestingSessionLocal()
+    client = TestClient(main_module.app)
+
+    resp = client.get("/no-such-file")
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- expose `/readyz` health check that performs a short `SELECT 1`
- serve frontend assets via FastAPI static mount at root
- document readiness probe
- test readiness behavior and static frontend
- fetch market data from `/markets/top?limit=20&vs=usd` on the frontend

## Testing
- `ruff check backend`
- `black backend/app tests/test_readyz.py tests/test_frontend_routes.py`
- `pytest`
- `pytest tests/test_frontend_routes.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bddf253490832780023330e9f22107