### PR TITLE
feat: add readiness probe and static frontend

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -21,10 +21,10 @@
   <table id="cryptos" style="display:none;">
     <thead>
       <tr>
-        <th>Name</th>
-        <th>Symbol</th>
+        <th>Coin</th>
         <th>Price (USD)</th>
-        <th>Score</th>
+        <th>Rank</th>
+        <th>24h %</th>
       </tr>
     </thead>
     <tbody></tbody>
@@ -58,9 +58,10 @@
         const latency = Math.round(performance.now() - start);
         lastRequest = { url, status: res.status, latency };
         const data = await res.json();
-        data.forEach(item => {
+        (data.items || []).forEach(item => {
           const tr = document.createElement('tr');
-          tr.innerHTML = `<td>${item.name}</td><td>${item.symbol}</td><td>${formatPrice(item.price)}</td><td>${item.score}</td>`;
+          const pct = item.pct_change_24h !== undefined && item.pct_change_24h !== null ? item.pct_change_24h.toFixed(2) : '';
+          tr.innerHTML = `<td>${item.coin_id}</td><td>${formatPrice(item.price)}</td><td>${item.rank ?? ''}</td><td>${pct}</td>`;
           tbody.appendChild(tr);
         });
         document.getElementById('cryptos').style.display = 'table';


### PR DESCRIPTION
## Summary
- expose `/readyz` health check that performs a short `SELECT 1`
- serve frontend assets via FastAPI static mount at root
- document readiness probe
- test readiness behavior and static frontend
- fetch market data from `/markets/top?limit=20&vs=usd` on the frontend
- handle `/api/markets/top` response structure in the frontend table

## Testing
- `pip install -r backend/requirements.txt`
- `ruff check backend`
- `black backend`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bde3f888088327a5a0888287bf6fa9