### PR TITLE
feat: add readiness probe, static frontend, ETL scheduler, and JSON logging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,9 +12,6 @@ CG_MONTHLY_QUOTA=10000
 CG_PER_PAGE_MAX=250
 CG_ALERT_THRESHOLD=0.7
 
-# Scheduling (ETL every 12h)
-REFRESH_CRON=0 */12 * * *
-
 # Persistence
 DATABASE_URL=sqlite:////volume1/docker/tokenlysis/db/tokenlysis.db
 BUDGET_FILE=/volume1/docker/tokenlysis/meta/cg_budget.json

--- a/backend/app/core/settings.py
+++ b/backend/app/core/settings.py
@@ -75,7 +75,6 @@ class Settings(BaseSettings):
     CG_MONTHLY_QUOTA: int = 10000
     CG_PER_PAGE_MAX: int = 250
     CG_ALERT_THRESHOLD: float = 0.7
-    REFRESH_CRON: str = "0 */12 * * *"
     BUDGET_FILE: str | None = None
     DATABASE_URL: str | None = None
     SEED_FILE: str = "./backend/app/seed/top20.json"

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -51,42 +51,7 @@
       document.getElementById('cryptos').style.display = 'none';
       const tbody = document.querySelector('#cryptos tbody');
       tbody.innerHTML = '';
-      const url = `${API_URL}/ranking?limit=20`;
-      const start = performance.now();
-      try {
-        const res = await fetch(url);
-        const latency = Math.round(performance.now() - start);
-        lastRequest = { url, status: res.status, latency };
-        if (!res.ok) {
-          await loadMarkets();
-          return;
-        }
-        const data = await res.json();
-        if (!data.items.length) {
-          await loadMarkets();
-          return;
-        }
-        data.items.forEach(item => {
-          const tr = document.createElement('tr');
-          tr.innerHTML = `<td>${item.name}</td><td>${item.symbol}</td><td>${formatPrice(item.latest.price_usd)}</td><td>${item.latest.scores.global}</td>`;
-          tbody.appendChild(tr);
-        });
-        statusEl.textContent = '';
-        document.getElementById('cryptos').style.display = 'table';
-        document.getElementById('demo-banner').style.display = 'none';
-      } catch (err) {
-        statusEl.innerHTML = `Error fetching data <button id="retry">Retry</button>`;
-        document.getElementById('retry').onclick = loadCryptos;
-        console.error(err);
-      }
-      loadDiag();
-    }
-
-    async function loadMarkets() {
-      const statusEl = document.getElementById('status');
-      const tbody = document.querySelector('#cryptos tbody');
-      tbody.innerHTML = '';
-      const url = `${API_URL}/markets?limit=20`;
+      const url = `${API_URL}/markets/top?limit=20&vs=usd`;
       const start = performance.now();
       try {
         const res = await fetch(url);
@@ -99,8 +64,7 @@
           tbody.appendChild(tr);
         });
         document.getElementById('cryptos').style.display = 'table';
-        statusEl.innerHTML = `données minimales (ETL indisponible) <button id="retry">Réessayer</button>`;
-        document.getElementById('retry').onclick = loadCryptos;
+        statusEl.textContent = '';
         document.getElementById('demo-banner').style.display = 'block';
       } catch (err) {
         statusEl.innerHTML = `Error fetching data <button id="retry">Retry</button>`;

--- a/tests/test_etl.py
+++ b/tests/test_etl.py
@@ -1,7 +1,10 @@
+import json
+import requests
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
+from backend.app.core.settings import settings
 from backend.app.db import Base
 from backend.app.etl import run as run_module
 from backend.app.services.budget import CallBudget
@@ -34,41 +37,212 @@ def test_run_etl_persists_and_logs(monkeypatch, tmp_path, caplog):
     Base.metadata.create_all(bind=engine)
     monkeypatch.setattr(run_module, "SessionLocal", TestingSessionLocal)
 
+    monkeypatch.setattr(settings, "CG_TOP_N", 10)
+    monkeypatch.setattr(settings, "CG_PER_PAGE_MAX", 10)
+
     budget = CallBudget(tmp_path / "budget.json", quota=10)
 
     class StubClient:
-        def get_markets(self, **kwargs):
+        def get_markets(self, *, vs, per_page, page):
+            assert per_page == 10
+            assert page == 1
             return [
                 {
-                    "id": "bitcoin",
-                    "current_price": 1.0,
-                    "market_cap": 1.0,
-                    "total_volume": 1.0,
-                    "market_cap_rank": 1,
+                    "id": f"coin{i}",
+                    "current_price": float(i),
+                    "market_cap": float(i),
+                    "total_volume": float(i),
+                    "market_cap_rank": i,
                     "price_change_percentage_24h": 0.0,
-                },
-                {
-                    "id": "ethereum",
-                    "current_price": 2.0,
-                    "market_cap": 2.0,
-                    "total_volume": 2.0,
-                    "market_cap_rank": 2,
-                    "price_change_percentage_24h": 1.0,
-                },
+                }
+                for i in range(10)
             ]
 
     with caplog.at_level("INFO"):
         rows = run_module.run_etl(client=StubClient(), budget=budget)
-    assert rows == 2
+    assert rows == 10
 
     session = TestingSessionLocal()
     prices_repo = PricesRepo(session)
     meta_repo = MetaRepo(session)
-    assert len(prices_repo.get_top("usd", 10)) == 2
+    assert len(prices_repo.get_top("usd", 10)) == 10
     assert meta_repo.get("data_source") == "api"
     assert meta_repo.get("monthly_call_count") == "1"
     assert budget.monthly_call_count == 1
-    record = next(r for r in caplog.records if r.message == "etl run completed")
-    assert record.coingecko_calls_total == 1
+    payload = None
+    for r in caplog.records:
+        try:
+            msg = json.loads(r.message)
+        except Exception:  # pragma: no cover - non-JSON logs
+            continue
+        if msg.get("event") == "etl run completed":
+            payload = msg
+            break
+    assert payload is not None
+    assert payload["coingecko_calls_total"] == 1
     assert meta_repo.get("last_refresh_at") is not None
     session.close()
+
+
+def test_run_etl_tracks_actual_calls(monkeypatch, tmp_path, caplog):
+    monkeypatch.setattr(settings, "CG_TOP_N", 1000)
+    monkeypatch.setattr(settings, "CG_PER_PAGE_MAX", 250)
+
+    class DummySession:
+        def commit(self) -> None:  # pragma: no cover - trivial
+            pass
+
+        def rollback(self) -> None:  # pragma: no cover - trivial
+            pass
+
+        def close(self) -> None:  # pragma: no cover - trivial
+            pass
+
+    class DummyPricesRepo:
+        def __init__(self, session) -> None:  # pragma: no cover - trivial
+            pass
+
+        def upsert_latest(self, rows) -> None:  # pragma: no cover - trivial
+            pass
+
+        def insert_snapshot(self, rows) -> None:  # pragma: no cover - trivial
+            pass
+
+    class DummyMetaRepo:
+        last_instance = None
+
+        def __init__(self, session) -> None:
+            self.data: dict[str, str] = {}
+            DummyMetaRepo.last_instance = self
+
+        def set(self, key: str, value: str) -> None:
+            self.data[key] = value
+
+    monkeypatch.setattr(run_module, "SessionLocal", lambda: DummySession())
+    monkeypatch.setattr(run_module, "PricesRepo", DummyPricesRepo)
+    monkeypatch.setattr(run_module, "MetaRepo", DummyMetaRepo)
+
+    class PagedClient:
+        def __init__(self) -> None:
+            self.calls: list[tuple[int, int]] = []
+
+        def get_markets(self, *, vs: str, per_page: int, page: int):
+            self.calls.append((per_page, page))
+            start = (page - 1) * per_page
+            return [
+                {
+                    "id": f"coin{start + i}",
+                    "current_price": 1.0,
+                    "market_cap": 1.0,
+                    "total_volume": 1.0,
+                    "market_cap_rank": start + i,
+                    "price_change_percentage_24h": 0.0,
+                }
+                for i in range(per_page)
+            ]
+
+    budget = CallBudget(tmp_path / "budget.json", quota=20)
+    client = PagedClient()
+    with caplog.at_level("INFO"):
+        rows = run_module.run_etl(client=client, budget=budget)
+
+    assert rows == 1000
+    assert budget.monthly_call_count == 4
+    assert DummyMetaRepo.last_instance.data["monthly_call_count"] == "4"
+    payload = None
+    for r in caplog.records:
+        try:
+            msg = json.loads(r.message)
+        except Exception:  # pragma: no cover - non-JSON logs
+            continue
+        if msg.get("event") == "etl run completed":
+            payload = msg
+            break
+    assert payload is not None
+    assert payload["coingecko_calls_total"] == 4
+    assert [call[1] for call in client.calls] == [1, 2, 3, 4]
+    assert all(call[0] == 250 for call in client.calls)
+
+
+def test_run_etl_downgrades_per_page_on_4xx(monkeypatch, tmp_path, caplog):
+    monkeypatch.setattr(settings, "CG_TOP_N", 1000)
+    monkeypatch.setattr(settings, "CG_PER_PAGE_MAX", 250)
+
+    class DummySession:
+        def commit(self) -> None:  # pragma: no cover - trivial
+            pass
+
+        def rollback(self) -> None:  # pragma: no cover - trivial
+            pass
+
+        def close(self) -> None:  # pragma: no cover - trivial
+            pass
+
+    class DummyPricesRepo:
+        def __init__(self, session) -> None:  # pragma: no cover - trivial
+            pass
+
+        def upsert_latest(self, rows) -> None:  # pragma: no cover - trivial
+            pass
+
+        def insert_snapshot(self, rows) -> None:  # pragma: no cover - trivial
+            pass
+
+    class DummyMetaRepo:
+        last_instance = None
+
+        def __init__(self, session) -> None:
+            self.data: dict[str, str] = {}
+            DummyMetaRepo.last_instance = self
+
+        def set(self, key: str, value: str) -> None:
+            self.data[key] = value
+
+    monkeypatch.setattr(run_module, "SessionLocal", lambda: DummySession())
+    monkeypatch.setattr(run_module, "PricesRepo", DummyPricesRepo)
+    monkeypatch.setattr(run_module, "MetaRepo", DummyMetaRepo)
+
+    class FallbackClient:
+        def __init__(self) -> None:
+            self.calls: list[tuple[int, int]] = []
+
+        def get_markets(self, *, vs: str, per_page: int, page: int):
+            self.calls.append((per_page, page))
+            if per_page > 100:
+                response = requests.Response()
+                response.status_code = 400
+                raise requests.HTTPError(response=response)
+            start = (page - 1) * per_page
+            return [
+                {
+                    "id": f"coin{start + i}",
+                    "current_price": 1.0,
+                    "market_cap": 1.0,
+                    "total_volume": 1.0,
+                    "market_cap_rank": start + i,
+                    "price_change_percentage_24h": 0.0,
+                }
+                for i in range(per_page)
+            ]
+
+    budget = CallBudget(tmp_path / "budget.json", quota=20)
+    client = FallbackClient()
+    with caplog.at_level("INFO"):
+        rows = run_module.run_etl(client=client, budget=budget)
+
+    assert rows == 1000
+    assert budget.monthly_call_count == 10
+    assert DummyMetaRepo.last_instance.data["monthly_call_count"] == "10"
+    payload = None
+    for r in caplog.records:
+        try:
+            msg = json.loads(r.message)
+        except Exception:  # pragma: no cover - non-JSON logs
+            continue
+        if msg.get("event") == "etl run completed":
+            payload = msg
+            break
+    assert payload is not None
+    assert payload["coingecko_calls_total"] == 10
+    assert client.calls[0] == (250, 1)
+    assert client.calls[1:] == [(100, i) for i in range(1, 11)]

--- a/tests/test_frontend_routes.py
+++ b/tests/test_frontend_routes.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+
+def test_frontend_fetches_markets_top():
+    html = Path("frontend/index.html").read_text()
+    assert "/markets/top?limit=20&vs=usd" in html
+    assert "/markets?" not in html.replace("/markets/top?limit=20&vs=usd", "")
+
+
+def test_frontend_no_ranking_call():
+    html = Path("frontend/index.html").read_text()
+    assert "/ranking" not in html
+
+
+def test_frontend_version_scripts_present():
+    html = Path("frontend/index.html").read_text()
+    assert '<script src="./app-version.js"></script>' in html
+    assert "import { getAppVersion } from './version.js';" in html

--- a/tests/test_healthz.py
+++ b/tests/test_healthz.py
@@ -1,0 +1,79 @@
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend.app.db import Base, get_session
+from backend.app.services.dao import MetaRepo
+
+
+def _setup_test_session(tmp_path):
+    engine = create_engine(
+        f"sqlite:///{tmp_path/'test.db'}", connect_args={"check_same_thread": False}
+    )
+    TestingSessionLocal = sessionmaker(
+        bind=engine, autoflush=False, autocommit=False, expire_on_commit=False
+    )
+    Base.metadata.create_all(bind=engine)
+    return TestingSessionLocal
+
+
+def test_healthz_ready(monkeypatch, tmp_path):
+    TestingSessionLocal = _setup_test_session(tmp_path)
+    session = TestingSessionLocal()
+    MetaRepo(session).set("bootstrap_done", "true")
+    session.commit()
+    session.close()
+
+    import backend.app.main as main_module
+
+    main_module.app.dependency_overrides[get_session] = lambda: TestingSessionLocal()
+    client = TestClient(main_module.app)
+
+    resp = client.get("/healthz")
+    data = resp.json()
+    assert resp.status_code == 200
+    assert data["ready"] is True
+    assert data["db_connected"] is True
+    assert data["bootstrap_done"] is True
+
+
+def test_healthz_not_bootstrapped(monkeypatch, tmp_path):
+    TestingSessionLocal = _setup_test_session(tmp_path)
+
+    import backend.app.main as main_module
+
+    main_module.app.dependency_overrides[get_session] = lambda: TestingSessionLocal()
+    client = TestClient(main_module.app)
+
+    resp = client.get("/healthz")
+    data = resp.json()
+    assert resp.status_code == 200
+    assert data["ready"] is False
+    assert data["bootstrap_done"] is False
+
+
+def test_healthz_db_error(monkeypatch):
+    class BrokenSession:
+        def execute(self, *_a, **_k):
+            raise RuntimeError("boom")
+
+        def close(self):
+            pass
+
+    def _broken_session():
+        session = BrokenSession()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    import backend.app.main as main_module
+
+    main_module.app.dependency_overrides[get_session] = _broken_session
+    client = TestClient(main_module.app)
+
+    resp = client.get("/healthz")
+    data = resp.json()
+    assert resp.status_code == 200
+    assert data["ready"] is False
+    assert data["db_connected"] is False

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,66 @@
+import json
+import logging
+import time
+from importlib import reload
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+def test_log_level_respects_env(monkeypatch):
+    monkeypatch.setenv("LOG_LEVEL", "DEBUG")
+    import backend.app.core.settings as settings_module
+
+    reload(settings_module)
+    import backend.app.main as main_module
+
+    reload(main_module)
+    monkeypatch.setattr(main_module, "run_etl", lambda *_, **__: None)
+    monkeypatch.setattr(main_module, "load_seed", lambda *_, **__: None)
+    with TestClient(main_module.app):
+        pass
+    assert logging.getLogger().getEffectiveLevel() == logging.DEBUG
+    logging.getLogger().setLevel(logging.WARNING)
+
+
+def test_coingecko_client_logs_json(monkeypatch, caplog):
+    from backend.app.services.coingecko import CoinGeckoClient
+
+    class DummyResp:
+        status_code = 200
+        headers = {"X-Request-Id": "rid"}
+        request = type("Req", (), {"headers": {}})()
+        url = "https://api.coingecko.com/api/v3/coins/markets"
+
+        def json(self):
+            return []
+
+        def raise_for_status(self):
+            pass
+
+    class DummySession:
+        def __init__(self) -> None:
+            self.headers = {}
+
+        def mount(self, prefix, adapter):
+            pass
+
+        def get(self, url, params=None, timeout=None):
+            return DummyResp()
+
+    counter = {"v": 0.0}
+
+    def fake_perf_counter() -> float:
+        counter["v"] += 0.001
+        return counter["v"]
+
+    monkeypatch.setattr(time, "perf_counter", fake_perf_counter)
+    monkeypatch.setattr(time, "sleep", lambda s: None)
+
+    client = CoinGeckoClient(api_key=None, session=DummySession())
+    with caplog.at_level("INFO"):
+        client.get_markets()
+    record = next(r for r in caplog.records if r.message.startswith("{"))
+    payload = json.loads(record.message)
+    assert payload["endpoint"] == "/coins/markets"
+    assert "latency_ms" in payload

--- a/tests/test_markets_api.py
+++ b/tests/test_markets_api.py
@@ -1,0 +1,66 @@
+import logging
+
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend.app.core.settings import settings
+from backend.app.db import Base, get_session
+from backend.app.services.dao import PricesRepo
+
+
+def _setup_test_session(tmp_path):
+    engine = create_engine(
+        f"sqlite:///{tmp_path/'test.db'}", connect_args={"check_same_thread": False}
+    )
+    TestingSessionLocal = sessionmaker(
+        bind=engine, autoflush=False, autocommit=False, expire_on_commit=False
+    )
+    Base.metadata.create_all(bind=engine)
+    return TestingSessionLocal
+
+
+def test_markets_top_limit_bound_and_logging(monkeypatch, tmp_path, caplog):
+    monkeypatch.setattr(settings, "CG_TOP_N", 100)
+    TestingSessionLocal = _setup_test_session(tmp_path)
+    import backend.app.main as main_module
+
+    monkeypatch.setattr(main_module.settings, "CG_TOP_N", 100)
+
+    main_module.app.dependency_overrides[get_session] = lambda: TestingSessionLocal()
+
+    called_limits: list[int] = []
+
+    def _get_top(self, vs: str, limit: int):
+        called_limits.append(limit)
+        return []
+
+    monkeypatch.setattr(PricesRepo, "get_top", _get_top)
+    client = TestClient(main_module.app)
+
+    with caplog.at_level(logging.INFO, logger="backend.app.main"):
+        resp = client.get("/api/markets/top?limit=500&vs=usd")
+    assert resp.status_code == 200
+    assert called_limits[-1] == 100
+    record = caplog.records[-1]
+    assert record.limit_effective == 100
+    assert record.vs == "usd"
+
+    with caplog.at_level(logging.INFO, logger="backend.app.main"):
+        resp = client.get("/api/markets/top?limit=0&vs=usd")
+    assert resp.status_code == 200
+    assert called_limits[-1] == 1
+    record = caplog.records[-1]
+    assert record.limit_effective == 1
+    assert record.vs == "usd"
+
+
+def test_markets_top_invalid_vs(monkeypatch, tmp_path):
+    TestingSessionLocal = _setup_test_session(tmp_path)
+    import backend.app.main as main_module
+
+    main_module.app.dependency_overrides[get_session] = lambda: TestingSessionLocal()
+    client = TestClient(main_module.app)
+
+    resp = client.get("/api/markets/top?limit=1&vs=eur")
+    assert resp.status_code == 400

--- a/tests/test_readyz.py
+++ b/tests/test_readyz.py
@@ -1,0 +1,76 @@
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend.app.db import Base, get_session
+
+
+def _setup_test_session(tmp_path):
+    engine = create_engine(
+        f"sqlite:///{tmp_path/'test.db'}", connect_args={"check_same_thread": False}
+    )
+    TestingSessionLocal = sessionmaker(
+        bind=engine, autoflush=False, autocommit=False, expire_on_commit=False
+    )
+    Base.metadata.create_all(bind=engine)
+    return TestingSessionLocal
+
+
+def test_readyz_ok(monkeypatch, tmp_path):
+    TestingSessionLocal = _setup_test_session(tmp_path)
+
+    import backend.app.main as main_module
+
+    main_module.app.dependency_overrides[get_session] = lambda: TestingSessionLocal()
+    client = TestClient(main_module.app)
+
+    resp = client.get("/readyz")
+    assert resp.status_code == 200
+    assert resp.json() == {"ready": True}
+
+
+def test_readyz_db_error(monkeypatch, tmp_path):
+    class BrokenSession:
+        def execute(self, *_a, **_k):
+            raise RuntimeError("boom")
+
+        def close(self):
+            pass
+
+    def _broken_session():
+        session = BrokenSession()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    import backend.app.main as main_module
+
+    main_module.app.dependency_overrides[get_session] = _broken_session
+    client = TestClient(main_module.app)
+
+    resp = client.get("/readyz")
+    assert resp.status_code == 503
+
+
+def test_frontend_served(monkeypatch, tmp_path):
+    TestingSessionLocal = _setup_test_session(tmp_path)
+    import backend.app.main as main_module
+
+    main_module.app.dependency_overrides[get_session] = lambda: TestingSessionLocal()
+    client = TestClient(main_module.app)
+
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert "<!DOCTYPE html>" in resp.text
+
+
+def test_frontend_missing_file(monkeypatch, tmp_path):
+    TestingSessionLocal = _setup_test_session(tmp_path)
+    import backend.app.main as main_module
+
+    main_module.app.dependency_overrides[get_session] = lambda: TestingSessionLocal()
+    client = TestClient(main_module.app)
+
+    resp = client.get("/no-such-file")
+    assert resp.status_code == 404

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,131 @@
+import asyncio
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend.app.db import Base
+from backend.app.services.dao import MetaRepo
+
+
+def _setup_test_session(tmp_path):
+    engine = create_engine(
+        f"sqlite:///{tmp_path/'test.db'}", connect_args={"check_same_thread": False}
+    )
+    TestingSessionLocal = sessionmaker(
+        bind=engine, autoflush=False, autocommit=False, expire_on_commit=False
+    )
+    Base.metadata.create_all(bind=engine)
+    return TestingSessionLocal
+
+
+def test_startup_runs_etl_when_not_bootstrapped(monkeypatch, tmp_path):
+    TestingSessionLocal = _setup_test_session(tmp_path)
+
+    def _session_override():
+        session = TestingSessionLocal()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    import backend.app.main as main_module
+
+    monkeypatch.setattr(main_module, "get_session", _session_override)
+    monkeypatch.setattr(main_module.asyncio, "create_task", lambda coro: coro.close())
+    called = {"etl": 0, "seed": 0}
+
+    def fake_run_etl(*_a, **_k):
+        called["etl"] += 1
+
+    def fake_load_seed():
+        called["seed"] += 1
+
+    monkeypatch.setattr(main_module, "run_etl", fake_run_etl)
+    monkeypatch.setattr(main_module, "load_seed", fake_load_seed)
+
+    asyncio.run(main_module.startup())
+
+    assert called["etl"] == 1
+    assert called["seed"] == 0
+
+
+def test_startup_loads_seed_when_bootstrapped(monkeypatch, tmp_path):
+    TestingSessionLocal = _setup_test_session(tmp_path)
+    session = TestingSessionLocal()
+    MetaRepo(session).set("bootstrap_done", "true")
+    session.commit()
+    session.close()
+
+    def _session_override():
+        session = TestingSessionLocal()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    import backend.app.main as main_module
+
+    monkeypatch.setattr(main_module, "get_session", _session_override)
+    monkeypatch.setattr(main_module.asyncio, "create_task", lambda coro: coro.close())
+    called = {"etl": 0, "seed": 0}
+
+    def fake_run_etl(*_a, **_k):
+        called["etl"] += 1
+
+    def fake_load_seed():
+        called["seed"] += 1
+
+    monkeypatch.setattr(main_module, "run_etl", fake_run_etl)
+    monkeypatch.setattr(main_module, "load_seed", fake_load_seed)
+
+    asyncio.run(main_module.startup())
+
+    assert called["etl"] == 0
+    assert called["seed"] == 1
+
+
+def test_scheduler_waits_between_runs(monkeypatch, tmp_path):
+    TestingSessionLocal = _setup_test_session(tmp_path)
+    session = TestingSessionLocal()
+    MetaRepo(session).set("bootstrap_done", "true")
+    session.commit()
+    session.close()
+
+    def _session_override():
+        session = TestingSessionLocal()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    import backend.app.main as main_module
+
+    monkeypatch.setattr(main_module, "get_session", _session_override)
+
+    run_calls = []
+    sleep_args = []
+
+    def fake_run_etl(*_a, **_k):
+        run_calls.append(1)
+
+    async def fake_sleep(seconds):
+        sleep_args.append(seconds)
+        raise RuntimeError
+
+    tasks = []
+
+    def fake_create_task(coro):
+        tasks.append(coro)
+        return None
+
+    monkeypatch.setattr(main_module, "run_etl", fake_run_etl)
+    monkeypatch.setattr(main_module, "load_seed", lambda: None)
+    monkeypatch.setattr(main_module.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(main_module.asyncio, "create_task", fake_create_task)
+
+    asyncio.run(main_module.startup())
+    assert len(tasks) == 1
+    with pytest.raises(RuntimeError):
+        asyncio.run(tasks[0])
+    assert run_calls == [1]
+    assert sleep_args == [12 * 60 * 60]

--- a/tests/test_version_api.py
+++ b/tests/test_version_api.py
@@ -1,0 +1,51 @@
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend.app.core.version import get_version
+from backend.app.db import Base, get_session
+
+
+def _setup_test_session(tmp_path):
+    engine = create_engine(
+        f"sqlite:///{tmp_path/'test.db'}", connect_args={"check_same_thread": False}
+    )
+    TestingSessionLocal = sessionmaker(
+        bind=engine, autoflush=False, autocommit=False, expire_on_commit=False
+    )
+    Base.metadata.create_all(bind=engine)
+    return TestingSessionLocal
+
+
+def test_version_from_env(monkeypatch, tmp_path):
+    TestingSessionLocal = _setup_test_session(tmp_path)
+    monkeypatch.setenv("APP_VERSION", "1.2.3")
+    import backend.app.main as main_module
+
+    monkeypatch.setattr(main_module, "run_etl", lambda *_, **__: 0)
+    main_module.app.dependency_overrides[get_session] = lambda: TestingSessionLocal()
+    client = TestClient(main_module.app)
+
+    expected = get_version()
+    resp = client.get("/version")
+    assert resp.status_code == 200
+    assert resp.json() == {"version": expected}
+
+    main_module.app.dependency_overrides.clear()
+
+
+def test_version_fallback(monkeypatch, tmp_path):
+    TestingSessionLocal = _setup_test_session(tmp_path)
+    monkeypatch.setenv("APP_VERSION", "dev")
+    import backend.app.main as main_module
+
+    monkeypatch.setattr(main_module, "run_etl", lambda *_, **__: 0)
+    main_module.app.dependency_overrides[get_session] = lambda: TestingSessionLocal()
+    client = TestClient(main_module.app)
+
+    expected = get_version()
+    resp = client.get("/api/version")
+    assert resp.status_code == 200
+    assert resp.json() == {"version": expected}
+
+    main_module.app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- expose `/readyz` health check that performs a short `SELECT 1`
- serve frontend assets via FastAPI static mount at root
- document readiness probe
- fetch market data from `/markets/top?limit=20&vs=usd` on the frontend
- expose version via `/version` and `/api/version`
- track real CoinGecko API calls with robust pagination and budgeting
- run ETL every 12 hours and load seed data after bootstrap
- validate `/api/markets/top` params and clamp limit
- tighten `/healthz` by checking DB connectivity and bootstrap status
- configure logging level via `LOG_LEVEL` and emit JSON logs for CoinGecko client and ETL

## Testing
- `pip install -r backend/requirements.txt`
- `ruff check backend`
- `black backend/app tests/test_readyz.py tests/test_frontend_routes.py tests/test_version_api.py tests/test_etl.py tests/test_scheduler.py tests/test_healthz.py tests/test_markets_api.py tests/test_api_db.py tests/test_logging.py`
- `pytest`
- `pytest tests/test_logging.py::test_coingecko_client_logs_json -q`


------
https://chatgpt.com/codex/tasks/task_e_68bddf253490832780023330e9f22107