### PR TITLE
fix: enforce real budget and enhance frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 .env
 secrets.env
 secrets/
+node_modules/

--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ Runtime behaviour can be tweaked with environment variables:
 - `CG_PER_PAGE_MAX` – preferred page size for `/coins/markets` calls (default: `250`)
 - `CG_ALERT_THRESHOLD` – fraction of the monthly quota that triggers a scope
   reduction (default: `0.7`)
+- `REFRESH_GRANULARITY` – cron-like hint exposed by `/api/diag` (default: `12h`).
+  Changing this value updates the ETL scheduler without restarting the app.
 - `COINGECKO_BASE_URL` – override for the CoinGecko API endpoint (defaults to the
   public URL or Pro URL based on `COINGECKO_PLAN`)
 - `COINGECKO_API_KEY` – optional API key for CoinGecko
@@ -163,15 +165,16 @@ seed assets (`C1`, `C2`, …) are mapped to real CoinGecko IDs through
 
 ### Health & Diagnostics
 
-- `GET /healthz` – returns DB connectivity, bootstrap status and `{"ready": bool}`
+- `GET /healthz` – returns DB connectivity, bootstrap status and last refresh time
 - `GET /readyz` – readiness check for the web process (`{"ready": true}`)
 - `GET /api/markets/basic` – minimal market data fallback
-- `GET /api/diag` – returns app version, outbound status and masked API key
+- `GET /api/diag` – debug info: plan, granularity, last refresh, ETL rows, call budget
 - `GET /version` – application version (`{"version": "<hash>"}`)
 
 ### Public API
 
-- `GET /api/markets/top` – top assets (`limit` clamped to `[1, CG_TOP_N]`, `vs` must be `usd`)
+- `GET /api/markets/top` – top assets (`limit` clamped to `[1, CG_TOP_N]`, `vs` must be `usd`),
+  returns `{ "items": [...], "last_refresh_at": "...", "stale": bool, "data_source": "api|seed" }`
 
 ### Synology NAS Deployment (POC)
 

--- a/backend/app/core/settings.py
+++ b/backend/app/core/settings.py
@@ -75,6 +75,7 @@ class Settings(BaseSettings):
     CG_MONTHLY_QUOTA: int = 10000
     CG_PER_PAGE_MAX: int = 250
     CG_ALERT_THRESHOLD: float = 0.7
+    REFRESH_GRANULARITY: str = "12h"
     BUDGET_FILE: str | None = None
     DATABASE_URL: str | None = None
     SEED_FILE: str = "./backend/app/seed/top20.json"

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -21,96 +21,20 @@
   <table id="cryptos" style="display:none;">
     <thead>
       <tr>
-        <th>Name</th>
-        <th>Symbol</th>
+        <th>Coin</th>
+        <th>Rank</th>
         <th>Price (USD)</th>
-        <th>Score</th>
+        <th>Market Cap</th>
+        <th>Volume 24h</th>
+        <th>Change 24h</th>
       </tr>
     </thead>
     <tbody></tbody>
   </table>
+  <div id="meta" style="margin-top:8px;font-size:0.9em;"></div>
   <div id="version"></div>
   <div id="diag"></div>
   <script src="./app-version.js"></script>
-  <script type="module">
-    import { getAppVersion } from './version.js';
-
-    const API_URL = document.querySelector('meta[name="api-url"]')?.content || '';
-    let lastRequest = {};
-
-    function formatPrice(p) {
-      if (p === null || p === undefined) return '';
-      if (p >= 1) return p.toFixed(2);
-      if (p >= 0.01) return p.toFixed(4);
-      return p.toFixed(6);
-    }
-
-    async function loadCryptos() {
-      const statusEl = document.getElementById('status');
-      statusEl.textContent = 'Loading...';
-      document.getElementById('cryptos').style.display = 'none';
-      const tbody = document.querySelector('#cryptos tbody');
-      tbody.innerHTML = '';
-      const url = `${API_URL}/markets/top?limit=20&vs=usd`;
-      const start = performance.now();
-      try {
-        const res = await fetch(url);
-        const latency = Math.round(performance.now() - start);
-        lastRequest = { url, status: res.status, latency };
-        const data = await res.json();
-        data.forEach(item => {
-          const tr = document.createElement('tr');
-          tr.innerHTML = `<td>${item.name}</td><td>${item.symbol}</td><td>${formatPrice(item.price)}</td><td>${item.score}</td>`;
-          tbody.appendChild(tr);
-        });
-        document.getElementById('cryptos').style.display = 'table';
-        statusEl.textContent = '';
-        document.getElementById('demo-banner').style.display = 'block';
-      } catch (err) {
-        statusEl.innerHTML = `Error fetching data <button id="retry">Retry</button>`;
-        document.getElementById('retry').onclick = loadCryptos;
-        console.error(err);
-      }
-      loadDiag();
-    }
-
-    async function loadVersion() {
-      const local = getAppVersion();
-      const el = document.getElementById('version');
-
-      if (local && local !== 'dev') {
-        el.textContent = `Version: ${local}`;
-        return;
-      }
-
-      try {
-        const res = await fetch(`${API_URL}/version`);
-        const data = await res.json();
-        el.textContent = `Version: ${data.version || 'unknown'}`;
-      } catch (err) {
-        console.error(err);
-        el.textContent = 'Version: dev';
-      }
-    }
-
-    async function loadDiag() {
-      try {
-        const res = await fetch(`${API_URL}/diag`);
-        const data = await res.json();
-        const diag = `URL: ${lastRequest.url || ''} (${lastRequest.status || ''} in ${lastRequest.latency || 0}ms) | plan=${data.plan} | granularity=${data.granularity} | last_etl_items=${data.last_etl_items}`;
-        document.getElementById('diag').textContent = diag;
-      } catch (err) {
-        document.getElementById('diag').textContent = 'Diag unavailable';
-        console.error(err);
-      }
-    }
-
-    function init() {
-      loadVersion();
-      loadCryptos();
-    }
-
-    window.addEventListener('DOMContentLoaded', init);
-  </script>
+  <script type="module" src="./main.js"></script>
 </body>
 </html>

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -1,0 +1,107 @@
+import { getAppVersion } from './version.js';
+import { extractItems, formatDiag, formatMeta, resolveVersion } from './utils.js';
+
+const API_URL = document.querySelector('meta[name="api-url"]')?.content || '';
+let lastRequest = {};
+let marketMeta = {};
+let diagMeta = null;
+
+function formatPrice(p) {
+  if (p === null || p === undefined) return '';
+  if (p >= 1) return p.toFixed(2);
+  if (p >= 0.01) return p.toFixed(4);
+  return p.toFixed(6);
+}
+
+function formatNumber(n) {
+  if (n === null || n === undefined) return '';
+  return Number(n).toLocaleString('en-US');
+}
+
+function formatPct(p) {
+  if (p === null || p === undefined) return '';
+  return `${p.toFixed(2)}%`;
+}
+
+export async function loadCryptos() {
+  const statusEl = document.getElementById('status');
+  statusEl.textContent = 'Loading...';
+  document.getElementById('cryptos').style.display = 'none';
+  const tbody = document.querySelector('#cryptos tbody');
+  tbody.innerHTML = '';
+  const url = `${API_URL}/markets/top?limit=20&vs=usd`;
+  const start = performance.now();
+  try {
+    const res = await fetch(url);
+    const latency = Math.round(performance.now() - start);
+    lastRequest = { url, status: res.status, latency };
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const json = await res.json();
+    const items = extractItems(json);
+    marketMeta = {
+      last_refresh_at: json.last_refresh_at,
+      stale: json.stale,
+      data_source: json.data_source,
+    };
+    items.forEach((item) => {
+      const tr = document.createElement('tr');
+      tr.innerHTML = `<td>${item.coin_id}</td><td>${item.rank ?? ''}</td><td>${formatPrice(item.price)}</td><td>${formatNumber(item.market_cap)}</td><td>${formatNumber(item.volume_24h)}</td><td>${formatPct(item.pct_change_24h)}</td>`;
+      tbody.appendChild(tr);
+    });
+    document.getElementById('cryptos').style.display = 'table';
+    statusEl.textContent = '';
+    document.getElementById('demo-banner').style.display = 'block';
+  } catch (err) {
+    statusEl.innerHTML = `Error fetching data <button id="retry">Retry</button>`;
+    document.getElementById('retry').onclick = loadCryptos;
+    console.error(err);
+  }
+  renderMeta();
+  await loadDiag();
+}
+
+export async function loadVersion() {
+  const el = document.getElementById('version');
+  const local = getAppVersion();
+  try {
+    const res = await fetch(`${API_URL}/version`);
+    if (res.ok) {
+      const data = await res.json();
+      el.textContent = `Version: ${resolveVersion(data.version, local)}`;
+      return;
+    }
+  } catch (err) {
+    console.error(err);
+  }
+  el.textContent = `Version: ${resolveVersion(null, local)}`;
+}
+
+export async function loadDiag() {
+  try {
+    const res = await fetch(`${API_URL}/diag`);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    diagMeta = data;
+    document.getElementById('diag').textContent = formatDiag(lastRequest, data);
+    renderMeta();
+  } catch (err) {
+    diagMeta = null;
+    document.getElementById('diag').textContent = formatDiag(lastRequest, null);
+    renderMeta();
+    console.error(err);
+  }
+}
+
+export function renderMeta() {
+  const el = document.getElementById('meta');
+  el.innerHTML = formatMeta(marketMeta, diagMeta ?? {});
+}
+
+export function init() {
+  loadVersion();
+  loadCryptos();
+}
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('DOMContentLoaded', init);
+}

--- a/frontend/utils.js
+++ b/frontend/utils.js
@@ -1,0 +1,33 @@
+export function extractItems(json) {
+  if (Array.isArray(json)) {
+    return json;
+  }
+  if (json && Array.isArray(json.items)) {
+    return json.items;
+  }
+  throw new Error("Invalid schema: missing 'items'");
+}
+
+export function formatDiag(lastRequest, data) {
+  const plan = data?.plan ?? 'unknown';
+  const granularity = data?.granularity ?? 'unknown';
+  const lastEtlItems = data?.last_etl_items ?? 'unknown';
+  return `URL: ${lastRequest.url || ''} (${lastRequest.status || ''} in ${lastRequest.latency || 0}ms) | plan=${plan} | granularity=${granularity} | last_etl_items=${lastEtlItems}`;
+}
+
+export function formatMeta(marketMeta = {}, diagMeta = {}) {
+  const plan = diagMeta.plan ?? 'unknown';
+  const lastRefresh = marketMeta.last_refresh_at
+    ? new Date(marketMeta.last_refresh_at).toISOString().slice(11, 16) + 'Z'
+    : 'unknown';
+  const source = marketMeta.data_source ?? 'unknown';
+  const items = diagMeta.last_etl_items ?? 'unknown';
+  const base = `Plan: ${plan} | Last refresh: ${lastRefresh} | Source: ${source} | Items: ${items}`;
+  return marketMeta.stale ? `${base} <span class="badge">stale</span>` : base;
+}
+
+export function resolveVersion(apiVersion, localVersion) {
+  if (apiVersion && apiVersion !== 'dev') return apiVersion;
+  if (localVersion) return localVersion;
+  return 'dev';
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,682 @@
+{
+  "name": "tokenlysis",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "tokenlysis",
+      "version": "1.0.0",
+      "dependencies": {
+        "jsdom": "^22.1.0"
+      }
+    },
+    "node_modules/@tootallnate/once": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/abab": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
+      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
+      "deprecated": "Use your platform's native atob() and btoa() methods instead",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-3.0.0.tgz",
+      "integrity": "sha512-N4u2ABATi3Qplzf0hWbVCdjenim8F3ojEXpBDF5hBpjzW182MjNGLqfmQ0SkSPeQ+V86ZXgeH8aXj6kayd4jgg==",
+      "license": "MIT",
+      "dependencies": {
+        "rrweb-cssom": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-4.0.0.tgz",
+      "integrity": "sha512-/mMTei/JXPqvFqQtfyTowxmJVwr2PVAeCcDxyFf6LhoOu/09TX2OX3kb2wzi4DMXcfj4OItwDOnhl5oziPnT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "abab": "^2.0.6",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^12.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/domexception": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
+      "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "license": "MIT",
+      "dependencies": {
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-22.1.0.tgz",
+      "integrity": "sha512-/9AVW7xNbsBv6GfWho4TTNjEo9fe6Zhf9O7s0Fhhr3u+awPwAJMKwAMXnkk5vBxflqLW9hTHX/0cs+P3gW+cQw==",
+      "license": "MIT",
+      "dependencies": {
+        "abab": "^2.0.6",
+        "cssstyle": "^3.0.0",
+        "data-urls": "^4.0.0",
+        "decimal.js": "^10.4.3",
+        "domexception": "^4.0.0",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.4",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.6.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.2",
+        "w3c-xmlserializer": "^4.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^2.0.0",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^12.0.1",
+        "ws": "^8.13.0",
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.22",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.22.tgz",
+      "integrity": "sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ==",
+      "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT"
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
+      "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==",
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
+      "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
+      "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-12.0.1.tgz",
+      "integrity": "sha512-Ed/LrqB8EPlGxjS+TrsXcpUond1mhccS3pchLhzSgPCnTimUCKj3IZE75pAs5m6heB2U2TMerKFUXheyHY+VDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^4.1.1",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
+      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "tokenlysis",
+  "version": "1.0.0",
+  "type": "module",
+  "dependencies": {
+    "jsdom": "^22.1.0"
+  }
+}

--- a/tests/test_api_db.py
+++ b/tests/test_api_db.py
@@ -68,3 +68,55 @@ def test_markets_top_reads_db_and_stale_flag(monkeypatch, tmp_path):
 
     resp = client.get("/api/markets/top?limit=1&vs=usd")
     assert resp.json()["stale"] is True
+
+
+def test_markets_top_wraps_items_and_limit(monkeypatch, tmp_path):
+    engine = create_engine(
+        f"sqlite:///{tmp_path/'test.db'}", connect_args={"check_same_thread": False}
+    )
+    TestingSessionLocal = sessionmaker(
+        bind=engine, autoflush=False, autocommit=False, expire_on_commit=False
+    )
+    Base.metadata.create_all(bind=engine)
+
+    session = TestingSessionLocal()
+    prices_repo = PricesRepo(session)
+    meta_repo = MetaRepo(session)
+    now = dt.datetime.now(dt.timezone.utc)
+    prices_repo.upsert_latest(
+        [
+            {
+                "coin_id": f"coin{i}",
+                "vs_currency": "usd",
+                "price": 1.0,
+                "market_cap": 1.0,
+                "volume_24h": 1.0,
+                "rank": i + 1,
+                "pct_change_24h": 0.0,
+                "snapshot_at": now,
+            }
+            for i in range(10)
+        ]
+    )
+    meta_repo.set("last_refresh_at", now.isoformat())
+    meta_repo.set("data_source", "api")
+    meta_repo.set("bootstrap_done", "true")
+    session.commit()
+    session.close()
+
+    import backend.app.main as main_module
+
+    def _fail(*_a, **_k):
+        raise AssertionError("run_etl should not be called")
+
+    monkeypatch.setattr(main_module, "run_etl", _fail)
+    main_module.app.dependency_overrides[get_session] = lambda: TestingSessionLocal()
+    main_module.app.router.on_startup = []
+    main_module.app.router.on_shutdown = []
+
+    client = TestClient(main_module.app)
+    resp = client.get("/api/markets/top?limit=5&vs=usd")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "items" in data
+    assert len(data["items"]) == 5

--- a/tests/test_diag.py
+++ b/tests/test_diag.py
@@ -1,0 +1,121 @@
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend.app.core.settings import settings
+from backend.app.db import Base, get_session
+from backend.app.services.dao import MetaRepo
+from backend.app.services.budget import CallBudget
+
+
+def _setup_test_session(tmp_path):
+    engine = create_engine(
+        f"sqlite:///{tmp_path/'test.db'}", connect_args={"check_same_thread": False}
+    )
+    TestingSessionLocal = sessionmaker(
+        bind=engine, autoflush=False, autocommit=False, expire_on_commit=False
+    )
+    Base.metadata.create_all(bind=engine)
+    return TestingSessionLocal
+
+
+def test_diag_returns_debug(monkeypatch, tmp_path):
+    TestingSessionLocal = _setup_test_session(tmp_path)
+    session = TestingSessionLocal()
+    meta = MetaRepo(session)
+    meta.set("last_refresh_at", "2025-09-07T20:51:26Z")
+    meta.set("last_etl_items", "50")
+    meta.set("data_source", "api")
+    meta.set("monthly_call_count", "999")
+    session.commit()
+    session.close()
+
+    budget = CallBudget(tmp_path / "budget.json", quota=settings.CG_MONTHLY_QUOTA)
+    budget.spend(2)
+
+    import backend.app.main as main_module
+
+    main_module.app.dependency_overrides[get_session] = lambda: TestingSessionLocal()
+    main_module.app.state.budget = budget
+
+    client = TestClient(main_module.app)
+    resp = client.get("/api/diag")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["plan"] == settings.COINGECKO_PLAN
+    assert data["granularity"] == "12h"
+    assert data["last_refresh_at"] == "2025-09-07T20:51:26Z"
+    assert data["last_etl_items"] == 50
+    assert data["monthly_call_count"] == 2
+    assert data["quota"] == settings.CG_MONTHLY_QUOTA
+    assert data["data_source"] == "api"
+    assert data["top_n"] == settings.CG_TOP_N
+
+
+def test_diag_uses_budget_over_meta(monkeypatch, tmp_path):
+    TestingSessionLocal = _setup_test_session(tmp_path)
+    session = TestingSessionLocal()
+    MetaRepo(session).set("monthly_call_count", "999")
+    session.commit()
+    session.close()
+
+    budget = CallBudget(tmp_path / "budget.json", quota=settings.CG_MONTHLY_QUOTA)
+    budget.spend(3)
+
+    import backend.app.main as main_module
+
+    main_module.app.dependency_overrides[get_session] = lambda: TestingSessionLocal()
+    main_module.app.state.budget = budget
+
+    client = TestClient(main_module.app)
+    resp = client.get("/api/diag")
+    data = resp.json()
+    assert data["monthly_call_count"] == 3
+
+
+def test_diag_no_budget(monkeypatch, tmp_path):
+    TestingSessionLocal = _setup_test_session(tmp_path)
+    import backend.app.main as main_module
+
+    main_module.app.dependency_overrides[get_session] = lambda: TestingSessionLocal()
+    main_module.app.state.budget = None
+
+    client = TestClient(main_module.app)
+    resp = client.get("/api/diag")
+    data = resp.json()
+    assert data["monthly_call_count"] == 0
+    assert data["last_refresh_at"] is None
+    assert data["last_etl_items"] == 0
+    assert data["data_source"] is None
+
+
+def test_diag_handles_invalid_last_etl_items(monkeypatch, tmp_path):
+    TestingSessionLocal = _setup_test_session(tmp_path)
+    session = TestingSessionLocal()
+    MetaRepo(session).set("last_etl_items", "oops")
+    session.commit()
+    session.close()
+
+    import backend.app.main as main_module
+
+    main_module.app.dependency_overrides[get_session] = lambda: TestingSessionLocal()
+    main_module.app.state.budget = None
+
+    client = TestClient(main_module.app)
+    resp = client.get("/api/diag")
+    data = resp.json()
+    assert data["last_etl_items"] == 0
+
+
+def test_diag_uses_configurable_granularity(monkeypatch, tmp_path):
+    TestingSessionLocal = _setup_test_session(tmp_path)
+    import backend.app.main as main_module
+
+    monkeypatch.setattr(main_module.settings, "REFRESH_GRANULARITY", "1h")
+    main_module.app.dependency_overrides[get_session] = lambda: TestingSessionLocal()
+    main_module.app.state.budget = None
+
+    client = TestClient(main_module.app)
+    resp = client.get("/api/diag")
+    data = resp.json()
+    assert data["granularity"] == "1h"

--- a/tests/test_frontend.js
+++ b/tests/test_frontend.js
@@ -1,0 +1,177 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { JSDOM } from 'jsdom';
+import { extractItems, formatDiag, formatMeta, resolveVersion } from '../frontend/utils.js';
+
+// T1: extractItems with array input returns same array
+
+test('extractItems returns array when json is array', () => {
+  const arr = [{ id: 1 }, { id: 2 }];
+  assert.deepEqual(extractItems(arr), arr);
+});
+
+// T2: extractItems with object containing items returns items array
+
+test('extractItems returns json.items when json has items array', () => {
+  const json = { items: [{ id: 3 }] };
+  assert.deepEqual(extractItems(json), json.items);
+});
+
+// T3: extractItems throws on missing items
+
+test('extractItems throws on invalid schema', () => {
+  assert.throws(() => extractItems({ foo: [] }), /Invalid schema: missing 'items'/);
+});
+
+// T4: formatDiag uses unknown values when data missing
+
+test('formatDiag falls back to unknown', () => {
+  const lr = { url: '/x', status: 200, latency: 1 };
+  assert.match(
+    formatDiag(lr, null),
+    /plan=unknown \| granularity=unknown \| last_etl_items=unknown/
+  );
+});
+
+// T5: formatMeta renders metadata with stale badge
+
+test('formatMeta renders metadata with stale badge', () => {
+  const marketMeta = {
+    last_refresh_at: '2025-09-07T20:51:26Z',
+    data_source: 'api',
+    stale: true,
+  };
+  const diagMeta = { plan: 'demo', last_etl_items: 50 };
+  const html = formatMeta(marketMeta, diagMeta);
+  assert.match(html, /Plan: demo/);
+  assert.match(html, /Last refresh: 20:51Z/);
+  assert.match(html, /Source: api/);
+  assert.match(html, /Items: 50/);
+  assert.match(html, /<span class="badge">stale<\/span>/);
+});
+
+// T6: formatMeta omits stale badge when not stale
+
+test('formatMeta omits stale badge when not stale', () => {
+  const marketMeta = {
+    last_refresh_at: '2025-09-07T20:51:26Z',
+    data_source: 'api',
+    stale: false,
+  };
+  const diagMeta = { plan: 'demo', last_etl_items: 50 };
+  const html = formatMeta(marketMeta, diagMeta);
+  assert.doesNotMatch(html, /badge/);
+});
+
+// T7: resolveVersion prefers API version over local dev
+
+test('resolveVersion prefers API version over local', () => {
+  assert.equal(resolveVersion('1.2.3', 'dev'), '1.2.3');
+});
+
+// T8: resolveVersion falls back to local when API version missing
+
+test('resolveVersion falls back to local', () => {
+  assert.equal(resolveVersion(null, '2.0.0'), '2.0.0');
+});
+
+// T9: resolveVersion defaults to dev when both missing
+
+test('resolveVersion defaults to dev', () => {
+  assert.equal(resolveVersion(null, null), 'dev');
+});
+
+// DOM Tests
+
+function setupDom() {
+  const dom = new JSDOM(`<!DOCTYPE html><meta name="api-url" content="">\n<div id="demo-banner" style="display:none"></div>\n<div id="status"></div>\n<table id="cryptos" style="display:none"><thead><tr><th>Coin</th><th>Rank</th><th>Price</th><th>Market Cap</th><th>Volume 24h</th><th>Change 24h</th></tr></thead><tbody></tbody></table>\n<div id="meta"></div>\n<div id="version"></div>\n<div id="diag"></div>`);
+  global.window = dom.window;
+  global.document = dom.window.document;
+  return dom;
+}
+
+test('loadCryptos renders table and diagnostics', async () => {
+  setupDom();
+  const { loadCryptos } = await import('../frontend/main.js');
+  const markets = {
+    items: [
+      {
+        coin_id: 'bitcoin',
+        rank: 1,
+        price: 1,
+        market_cap: 2,
+        volume_24h: 3,
+        pct_change_24h: 4,
+      },
+    ],
+    last_refresh_at: '2025-09-07T20:51:26Z',
+    stale: false,
+    data_source: 'api',
+  };
+  const diag = {
+    plan: 'demo',
+    granularity: '12h',
+    last_refresh_at: '2025-09-07T20:51:26Z',
+    last_etl_items: 50,
+    monthly_call_count: 1,
+    quota: 10000,
+    data_source: 'api',
+    top_n: 50,
+  };
+  global.fetch = async (url) => {
+    if (url.endsWith('/markets/top?limit=20&vs=usd')) {
+      return new Response(JSON.stringify(markets), { status: 200 });
+    }
+    if (url.endsWith('/diag')) {
+      return new Response(JSON.stringify(diag), { status: 200 });
+    }
+    if (url.endsWith('/version')) {
+      return new Response(JSON.stringify({ version: '1.0.0' }), { status: 200 });
+    }
+    throw new Error('unexpected fetch ' + url);
+  };
+
+  await loadCryptos();
+
+  const cells = [...document.querySelectorAll('#cryptos tbody tr td')].map((c) => c.textContent);
+  assert.deepEqual(cells, ['bitcoin', '1', '1.00', '2', '3', '4.00%']);
+  assert.match(document.getElementById('diag').textContent, /plan=demo/);
+});
+
+test('loadCryptos tolerates diag failure', async () => {
+  setupDom();
+  const { loadCryptos } = await import('../frontend/main.js');
+  const markets = {
+    items: [
+      {
+        coin_id: 'bitcoin',
+        rank: 1,
+        price: 1,
+        market_cap: 2,
+        volume_24h: 3,
+        pct_change_24h: 4,
+      },
+    ],
+    last_refresh_at: '2025-09-07T20:51:26Z',
+    stale: false,
+    data_source: 'api',
+  };
+  global.fetch = async (url) => {
+    if (url.endsWith('/markets/top?limit=20&vs=usd')) {
+      return new Response(JSON.stringify(markets), { status: 200 });
+    }
+    if (url.endsWith('/diag')) {
+      return new Response('oops', { status: 500 });
+    }
+    if (url.endsWith('/version')) {
+      return new Response(JSON.stringify({ version: '1.0.0' }), { status: 200 });
+    }
+    throw new Error('unexpected fetch ' + url);
+  };
+
+  await loadCryptos();
+
+  const firstCell = document.querySelector('#cryptos tbody tr td').textContent;
+  assert.equal(firstCell, 'bitcoin');
+  assert.match(document.getElementById('diag').textContent, /plan=unknown/);
+});

--- a/tests/test_frontend_routes.py
+++ b/tests/test_frontend_routes.py
@@ -2,9 +2,9 @@ from pathlib import Path
 
 
 def test_frontend_fetches_markets_top():
-    html = Path("frontend/index.html").read_text()
-    assert "/markets/top?limit=20&vs=usd" in html
-    assert "/markets?" not in html.replace("/markets/top?limit=20&vs=usd", "")
+    js = Path("frontend/main.js").read_text()
+    assert "/markets/top?limit=20&vs=usd" in js
+    assert "/markets?" not in js.replace("/markets/top?limit=20&vs=usd", "")
 
 
 def test_frontend_no_ranking_call():
@@ -15,4 +15,4 @@ def test_frontend_no_ranking_call():
 def test_frontend_version_scripts_present():
     html = Path("frontend/index.html").read_text()
     assert '<script src="./app-version.js"></script>' in html
-    assert "import { getAppVersion } from './version.js';" in html
+    assert '<script type="module" src="./main.js"></script>' in html


### PR DESCRIPTION
## Summary
- spend CoinGecko budget per real API call and stop when exhausted
- expose configurable refresh granularity and document variable
- expand frontend to use full market fields with DOM tests
- reschedule ETL loop based on REFRESH_GRANULARITY changes

## Testing
- `black backend/app/main.py tests/test_scheduler.py`
- `ruff check backend`
- `pytest`
- `npm install`
- `node tests/test_frontend.js`


------
https://chatgpt.com/codex/tasks/task_e_68bdf362e98c832788cd3915b79c8a91