### PR TITLE
Propagate build version across backend, Docker, and CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,13 +18,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Export commit SHA
+      - name: Compute meta
         run: echo "GIT_COMMIT=${GITHUB_SHA}" >> $GITHUB_ENV
-
       - name: Show computed version
         run: echo "APP_VERSION=${APP_VERSION}"
-
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -48,6 +45,7 @@ jobs:
         run: |
           docker buildx build \
             --build-arg APP_VERSION="${APP_VERSION}" \
+            --label "org.opencontainers.image.version=${APP_VERSION}" \
             --label "org.opencontainers.image.revision=${GIT_COMMIT}" \
             -f Dockerfile . \
             --load   # charge l'image localement pour validation (pas de push)
@@ -59,6 +57,7 @@ jobs:
       #     OWNER_LC="$(echo "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
       #     docker buildx build \
       #       --build-arg APP_VERSION="${APP_VERSION}" \
+      #       --label "org.opencontainers.image.version=${APP_VERSION}" \
       #       --label "org.opencontainers.image.revision=${GIT_COMMIT}" \
       #       -f Dockerfile . \
       #       --push \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@
 FROM python:3.11.8-slim
 
 ARG APP_VERSION=dev
-LABEL org.opencontainers.image.version=$APP_VERSION
-ENV APP_VERSION=$APP_VERSION
+ENV APP_VERSION=${APP_VERSION}
+LABEL org.opencontainers.image.version=${APP_VERSION}
 
 WORKDIR /app
 
@@ -12,8 +12,8 @@ RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/* \
     && pip install --no-cache-dir -r requirements.txt
 COPY backend ./backend
 COPY frontend ./frontend
-RUN echo "${APP_VERSION}" > VERSION \
-    && echo "window.APP_VERSION='${APP_VERSION}';" > frontend/app-version.js
+RUN printf "%s" "${APP_VERSION}" > /app/VERSION \
+ && printf "window.APP_VERSION='%s';\n" "${APP_VERSION}" > /app/frontend/app-version.js
 
 EXPOSE 8000
 CMD ["uvicorn", "backend.app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -99,6 +99,13 @@ uvicorn backend.app.main:app --reload
 The frontend is served statically by the API under `/` while the REST endpoints
 are exposed under `/api`.
 
+Set `APP_VERSION` when launching locally so the interface displays the
+expected version:
+
+```bash
+APP_VERSION=1.2.3 uvicorn backend.app.main:app --reload
+```
+
 #### Configuration
 
 Copy `.env.example` to `.env` and adjust the values as needed. This file holds sensitive settings such as API keys and database passwords. Keep it outside version control (it is ignored by `.gitignore`) and restrict access on your NAS, for example with `chmod 600 .env`.
@@ -208,27 +215,25 @@ the local source code.
 4. **Build and start** – from the NAS terminal run:
 
    ```bash
-   docker compose -f docker-compose.yml -f docker-compose.synology.yml up -d --build
+   APP_VERSION=1.0.123 \
+   docker compose -f docker-compose.yml -f docker-compose.synology.yml build --no-cache
+   docker compose -f docker-compose.yml -f docker-compose.synology.yml up -d
    ```
 
-   This builds the image with the main `Dockerfile` and forwards an optional
-   `APP_VERSION` build argument. Define `APP_VERSION` to pin a specific version
-   or let it default to `dev`.
-   A healthcheck inside the container polls `http://localhost:8000/readyz` every 30 seconds.
+   The build step injects the desired version into the image (defaults to
+   `dev`). The subsequent `up` starts the container. A healthcheck inside the
+   container polls `http://localhost:8000/readyz` every 30 seconds.
 5. **Access the app** – once running the interface is available at
    `http://<NAS_IP>:8002`.
 
 #### Updating
 
-When new commits are pushed to the repository you can rebuild the container to
-fetch the latest code. Either use the Synology UI’s **Recreate** option or run:
-
+To update with a pinned version:
 ```bash
-docker compose -f docker-compose.yml -f docker-compose.synology.yml up -d --build
+APP_VERSION=1.0.123 \
+docker compose -f docker-compose.yml -f docker-compose.synology.yml build --no-cache
+docker compose -f docker-compose.yml -f docker-compose.synology.yml up -d
 ```
-
-The `--build` flag forces Compose to rebuild the image, ensuring the container
-runs the newest version of Tokenlysis.
 
 ### Testing
 
@@ -250,6 +255,15 @@ building locally you can override the version:
 
 ```bash
 docker build --build-arg APP_VERSION=42 -t tokenlysis:test -f ./Dockerfile .
+```
+
+To propagate a new version to the dashboard and API, the image must be rebuilt
+with the desired value:
+
+```bash
+APP_VERSION=1.2.3 \
+docker compose -f docker-compose.yml -f docker-compose.synology.yml build --no-cache
+docker compose -f docker-compose.yml -f docker-compose.synology.yml up -d
 ```
 
 At runtime the container exposes `APP_VERSION` so it can be inspected with

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -43,4 +43,3 @@ if context.is_offline_mode():
     run_migrations_offline()
 else:
     run_migrations_online()
-

--- a/backend/alembic/versions/0001_baseline.py
+++ b/backend/alembic/versions/0001_baseline.py
@@ -64,4 +64,3 @@ def downgrade() -> None:
     op.drop_index("ix_latest_prices_rank", table_name="latest_prices")
     op.drop_table("latest_prices")
     op.drop_table("coins")
-

--- a/backend/app/core/version.py
+++ b/backend/app/core/version.py
@@ -2,35 +2,30 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from subprocess import CalledProcessError, check_output
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
+REPO_ROOT = Path("/app")
 
 
 def get_version() -> str:
     """Return the application version.
 
-    Prefer the ``APP_VERSION`` environment variable when set to a value other
-    than the placeholder ``dev``. When not provided, attempt to read the
-    version from a VERSION file generated at build time. As a final fallback,
-    return the number of commits in the repository. If everything fails, return
-    ``"0"``.
+    Resolution order:
+      1) ``APP_VERSION`` environment variable when set and not ``"dev"``
+      2) contents of ``/app/VERSION`` written at build time
+      3) fallback to ``"dev"``
     """
 
     env_version = os.getenv("APP_VERSION")
     if env_version and env_version != "dev":
-        return env_version[:7] if len(env_version) == 40 else env_version
+        return env_version
 
     version_file = REPO_ROOT / "VERSION"
     if version_file.exists():
-        version = version_file.read_text().strip()
-        return version[:7] if len(version) == 40 else version
+        content = version_file.read_text().strip()
+        if content:
+            return content
 
-    try:
-        output = check_output(["git", "rev-list", "--count", "HEAD"], cwd=REPO_ROOT)
-        return output.decode().strip()
-    except (CalledProcessError, FileNotFoundError):
-        return env_version or "0"
+    return "dev"
 
 
 __all__ = ["get_version"]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -185,6 +185,7 @@ async def startup() -> None:
         format="%(message)s",
         force=True,
     )
+    logger.info("startup", extra={"version": get_version()})
     Base.metadata.create_all(bind=engine)
     budget = None
     if settings.BUDGET_FILE:

--- a/docker-compose.synology.yml
+++ b/docker-compose.synology.yml
@@ -4,7 +4,7 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        APP_VERSION: "${APP_VERSION:-dev}"
+        APP_VERSION: ${APP_VERSION:-dev}
     env_file:
       - .env
     volumes:
@@ -17,4 +17,3 @@ services:
       test: ["CMD-SHELL", "curl -fsS http://localhost:8000/readyz || exit 1"]
       interval: 30s
       retries: 3
-

--- a/frontend/utils.test.js
+++ b/frontend/utils.test.js
@@ -1,0 +1,18 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveVersion } from './utils.js';
+
+// T1: API version wins when not 'dev'
+test('resolveVersion prioritizes API version when provided and not dev', () => {
+  assert.equal(resolveVersion('1.2.3', '0.0.1'), '1.2.3');
+});
+
+// T2: Local version used when API version is 'dev'
+test("resolveVersion falls back to local version when API version is 'dev'", () => {
+  assert.equal(resolveVersion('dev', '1.2.3'), '1.2.3');
+});
+
+// T3: Default to 'dev' when neither source provides a version
+test('resolveVersion returns dev when both versions are missing', () => {
+  assert.equal(resolveVersion(null, null), 'dev');
+});

--- a/frontend/version.test.js
+++ b/frontend/version.test.js
@@ -1,0 +1,20 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { getAppVersion } from './version.js';
+
+// T4: window.APP_VERSION is used when defined
+test('getAppVersion returns window.APP_VERSION when set', () => {
+  delete process.env.APP_VERSION;
+  delete process.env.NEXT_PUBLIC_APP_VERSION;
+  global.window = { APP_VERSION: '1.2.3' };
+  assert.equal(getAppVersion(), '1.2.3');
+  delete global.window;
+});
+
+// T5: defaults to dev when nothing provided
+test('getAppVersion returns dev when no sources define version', () => {
+  delete process.env.APP_VERSION;
+  delete process.env.NEXT_PUBLIC_APP_VERSION;
+  delete global.window;
+  assert.equal(getAppVersion(), 'dev');
+});

--- a/tests/test_version_endpoint.py
+++ b/tests/test_version_endpoint.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend.app.db import Base, get_session
+
+
+def _setup_test_session(tmp_path):
+    engine = create_engine(
+        f"sqlite:///{tmp_path/'test.db'}", connect_args={"check_same_thread": False}
+    )
+    TestingSessionLocal = sessionmaker(
+        bind=engine, autoflush=False, autocommit=False, expire_on_commit=False
+    )
+    Base.metadata.create_all(bind=engine)
+    return TestingSessionLocal
+
+
+def _make_client(monkeypatch, tmp_path):
+    TestingSessionLocal = _setup_test_session(tmp_path)
+    import backend.app.main as main_module
+
+    monkeypatch.setattr(main_module, "run_etl", lambda *_, **__: 0)
+    main_module.app.dependency_overrides[get_session] = lambda: TestingSessionLocal()
+    client = TestClient(main_module.app)
+    return client, main_module
+
+
+def test_env_version(monkeypatch, tmp_path):
+    monkeypatch.setenv("APP_VERSION", "7.7.7")
+    client, main_module = _make_client(monkeypatch, tmp_path)
+    resp = client.get("/api/version")
+    assert resp.status_code == 200
+    assert resp.json() == {"version": "7.7.7"}
+    main_module.app.dependency_overrides.clear()
+
+
+def test_file_version(monkeypatch, tmp_path):
+    monkeypatch.delenv("APP_VERSION", raising=False)
+    monkeypatch.setattr(
+        "backend.app.core.version.REPO_ROOT", tmp_path
+    )
+    (tmp_path / "VERSION").write_text("8.8.8")
+    client, main_module = _make_client(monkeypatch, tmp_path)
+    resp = client.get("/api/version")
+    assert resp.status_code == 200
+    assert resp.json() == {"version": "8.8.8"}
+    main_module.app.dependency_overrides.clear()
+
+
+def test_default_dev(monkeypatch, tmp_path):
+    monkeypatch.delenv("APP_VERSION", raising=False)
+    monkeypatch.setattr(
+        "backend.app.core.version.REPO_ROOT", tmp_path
+    )
+    client, main_module = _make_client(monkeypatch, tmp_path)
+    resp = client.get("/api/version")
+    assert resp.status_code == 200
+    assert resp.json() == {"version": "dev"}
+    main_module.app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- simplify get_version and point REPO_ROOT to /app
- deduplicate Dockerfile version injection and define commit metadata in CI
- streamline NAS build instructions
- tidy commit metadata export in workflow
- document deterministic NAS rebuild flow

## Testing
- `black backend`
- `ruff check backend`
- `pytest`
- `node --test frontend/utils.test.js frontend/version.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68be9b461c308327bd24f8365318ec28