### PR TITLE
feat: expose coin categories

### DIFF
--- a/backend/alembic/versions/0002_add_category_columns.py
+++ b/backend/alembic/versions/0002_add_category_columns.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0002_add_category_columns"
+down_revision = "0001_baseline"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("coins", sa.Column("category_names", sa.Text(), nullable=True))
+    op.add_column("coins", sa.Column("category_ids", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("coins", "category_ids")
+    op.drop_column("coins", "category_names")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -16,7 +16,8 @@ class Coin(Base):
     id: Mapped[str] = mapped_column(String, primary_key=True)
     symbol: Mapped[str] = mapped_column(String, nullable=False)
     name: Mapped[str] = mapped_column(String, nullable=False)
-    categories: Mapped[str | None] = mapped_column(Text, nullable=True)
+    category_names: Mapped[str | None] = mapped_column(Text, nullable=True)
+    category_ids: Mapped[str | None] = mapped_column(Text, nullable=True)
     updated_at: Mapped[dt.datetime | None] = mapped_column(DateTime(timezone=True))
 
 

--- a/backend/app/schemas/crypto.py
+++ b/backend/app/schemas/crypto.py
@@ -23,6 +23,8 @@ class CryptoSummary(BaseModel):
     symbol: str
     name: str
     sectors: List[str]
+    category_names: List[str] = Field(default_factory=list)
+    category_ids: List[str] = Field(default_factory=list)
     latest: Latest
 
 
@@ -38,6 +40,8 @@ class CryptoDetail(BaseModel):
     symbol: str
     name: str
     sectors: List[str]
+    category_names: List[str] = Field(default_factory=list)
+    category_ids: List[str] = Field(default_factory=list)
     latest: Latest
 
 

--- a/backend/app/services/categories.py
+++ b/backend/app/services/categories.py
@@ -1,0 +1,16 @@
+"""Category helpers."""
+
+from __future__ import annotations
+
+import re
+
+
+def slugify(name: str) -> str:
+    """Normalize category name to a slug id."""
+    lowered = name.lower()
+    no_paren = re.sub(r"\([^)]*\)", "", lowered)
+    cleaned = re.sub(r"[^a-z0-9]+", "-", no_paren)
+    return cleaned.strip("-")
+
+
+__all__ = ["slugify"]

--- a/backend/app/services/coingecko.py
+++ b/backend/app/services/coingecko.py
@@ -152,3 +152,28 @@ class CoinGeckoClient:
         return self._request(
             f"/coins/{coin_id.lower()}/market_chart/range", params=params
         ).json()
+
+    def get_coin_categories(self, coin_id: str) -> list[str]:
+        params = {
+            "localization": "false",
+            "tickers": "false",
+            "market_data": "false",
+            "community_data": "false",
+            "developer_data": "false",
+            "sparkline": "false",
+        }
+        try:
+            data = self._request(f"/coins/{coin_id.lower()}", params=params).json()
+            cats = data.get("categories", [])
+            if isinstance(cats, list):
+                return [c for c in cats if isinstance(c, str)]
+        except requests.HTTPError as exc:  # pragma: no cover - defensive
+            logger.warning("coin categories fetch failed for %s: %s", coin_id, exc)
+        return []
+
+    def get_categories_list(self) -> list[dict]:
+        try:
+            return self._request("/coins/categories/list").json()
+        except requests.HTTPError as exc:  # pragma: no cover - defensive
+            logger.warning("categories list fetch failed: %s", exc)
+            return []

--- a/backend/app/services/dao.py
+++ b/backend/app/services/dao.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+import datetime as dt
 from typing import Iterable
 
 from sqlalchemy import select, insert
 from sqlalchemy.dialects.sqlite import insert as sqlite_upsert
 from sqlalchemy.orm import Session
 
-from ..models import LatestPrice, Meta, Price
+from ..models import Coin, LatestPrice, Meta, Price
 
 
 class PricesRepo:
@@ -53,6 +54,92 @@ class PricesRepo:
         self.session.execute(insert(Price), list(rows))
 
 
+class CoinsRepo:
+    def __init__(self, session: Session) -> None:
+        self.session = session
+
+    def upsert(self, rows: Iterable[dict]) -> None:
+        if not rows:
+            return
+        stmt = sqlite_upsert(Coin).values(list(rows))
+        stmt = stmt.on_conflict_do_update(
+            index_elements=[Coin.id],
+            set_={
+                "symbol": stmt.excluded.symbol,
+                "name": stmt.excluded.name,
+                "category_names": stmt.excluded.category_names,
+                "category_ids": stmt.excluded.category_ids,
+                "updated_at": stmt.excluded.updated_at,
+            },
+        )
+        self.session.execute(stmt)
+
+    def get_categories(self, coin_id: str) -> tuple[list[str], list[str]]:
+        stmt = select(Coin.category_names, Coin.category_ids).where(Coin.id == coin_id)
+        row = self.session.execute(stmt).first()
+        if not row:
+            return [], []
+        import json
+
+        names = json.loads(row[0]) if row[0] else []
+        ids = json.loads(row[1]) if row[1] else []
+        return names, ids
+
+    def get_categories_bulk(
+        self, coin_ids: list[str]
+    ) -> dict[str, tuple[list[str], list[str]]]:
+        if not coin_ids:
+            return {}
+        stmt = select(Coin.id, Coin.category_names, Coin.category_ids).where(
+            Coin.id.in_(coin_ids)
+        )
+        rows = self.session.execute(stmt).all()
+        import json
+
+        return {
+            r[0]: (
+                json.loads(r[1]) if r[1] else [],
+                json.loads(r[2]) if r[2] else [],
+            )
+            for r in rows
+        }
+
+    def get_categories_with_timestamps(
+        self, coin_ids: list[str]
+    ) -> dict[str, tuple[list[str], list[str], dt.datetime | None]]:
+        if not coin_ids:
+            return {}
+        stmt = select(
+            Coin.id, Coin.category_names, Coin.category_ids, Coin.updated_at
+        ).where(Coin.id.in_(coin_ids))
+        rows = self.session.execute(stmt).all()
+        import json
+
+        return {
+            r[0]: (
+                json.loads(r[1]) if r[1] else [],
+                json.loads(r[2]) if r[2] else [],
+                r[3],
+            )
+            for r in rows
+        }
+
+    def get_categories_with_timestamp(
+        self, coin_id: str
+    ) -> tuple[list[str], list[str], dt.datetime | None]:
+        stmt = select(Coin.category_names, Coin.category_ids, Coin.updated_at).where(
+            Coin.id == coin_id
+        )
+        row = self.session.execute(stmt).first()
+        if not row:
+            return [], [], None
+        import json
+
+        names = json.loads(row[0]) if row[0] else []
+        ids = json.loads(row[1]) if row[1] else []
+        return names, ids, row[2]
+
+
 class MetaRepo:
     def __init__(self, session: Session) -> None:
         self.session = session
@@ -69,4 +156,4 @@ class MetaRepo:
         self.session.execute(stmt)
 
 
-__all__ = ["PricesRepo", "MetaRepo"]
+__all__ = ["PricesRepo", "MetaRepo", "CoinsRepo"]

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -10,6 +10,7 @@
     th, td { border: 1px solid #ccc; padding: 8px; text-align: left; }
     th { background-color: #f2f2f2; }
     #status { margin: 10px 0; }
+    .badge { background:#eee; border-radius:4px; padding:2px 4px; margin-right:2px; }
   </style>
 </head>
 <body>
@@ -21,6 +22,7 @@
     <thead>
       <tr>
         <th>Coin</th>
+        <th>Catégories</th>
         <th>Rank</th>
         <th>Price (USD)</th>
         <th>Market Cap</th>

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -3,6 +3,7 @@ import { extractItems, resolveVersion } from './utils.js';
 
 const API_URL = document.querySelector('meta[name="api-url"]')?.content || '';
 let appVersion = 'unknown';
+export const selectedCategories = [];
 
 function formatPrice(p) {
   if (p === null || p === undefined) return '';
@@ -39,12 +40,25 @@ export async function loadCryptos() {
       : 'Dernière mise à jour : inconnue';
     items.forEach((item) => {
       const tr = document.createElement('tr');
-      tr.innerHTML = `<td>${item.coin_id}</td><td>${item.rank ?? ''}</td><td>${formatPrice(item.price)}</td><td>${formatNumber(item.market_cap)}</td><td>${formatNumber(item.volume_24h)}</td><td>${formatPct(item.pct_change_24h)}</td>`;
+      const cats = item.category_names || [];
+      let badges = '';
+      cats.slice(0, 3).forEach((name) => {
+        badges += `<span class="badge">${name}</span> `;
+      });
+      if (cats.length > 3) {
+        badges += `<span class="badge">+${cats.length - 3}</span>`;
+      }
+      tr.innerHTML = `<td>${item.coin_id}</td><td>${badges.trim()}</td><td>${item.rank ?? ''}</td><td>${formatPrice(item.price)}</td><td>${formatNumber(item.market_cap)}</td><td>${formatNumber(item.volume_24h)}</td><td>${formatPct(item.pct_change_24h)}</td>`;
       tbody.appendChild(tr);
     });
     document.getElementById('cryptos').style.display = 'table';
     statusEl.textContent = '';
-    document.getElementById('demo-banner').style.display = 'block';
+    try {
+      const diag = await fetch(`${API_URL}/diag`).then(r => (r.ok ? r.json() : null));
+      if (diag?.plan === 'demo') {
+        document.getElementById('demo-banner').style.display = 'block';
+      }
+    } catch {}
   } catch (err) {
     statusEl.innerHTML = `Error fetching data <button id="retry">Retry</button>`;
     document.getElementById('retry').onclick = loadCryptos;

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -1,0 +1,144 @@
+import json
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend.app.db import Base, get_session
+from backend.app.services.coingecko import CoinGeckoClient
+from backend.app.services.categories import slugify
+from backend.app.schemas.crypto import CryptoSummary, Latest, Scores
+import backend.app.main as main_module
+from backend.app.etl import run as run_module
+
+
+class DummyResp:
+    def __init__(self, data, status_code=200):
+        self._data = data
+        self.status_code = status_code
+        self.headers = {}
+        self.url = "https://example.org"
+
+    def json(self):
+        return self._data
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            import requests
+            raise requests.HTTPError(response=self)
+
+
+def _setup_db(tmp_path):
+    engine = create_engine(
+        f"sqlite:///{tmp_path/'test.db'}", connect_args={"check_same_thread": False}
+    )
+    TestingSessionLocal = sessionmaker(
+        bind=engine, autoflush=False, autocommit=False, expire_on_commit=False
+    )
+    Base.metadata.create_all(bind=engine)
+    return TestingSessionLocal
+
+
+def test_slugify_normalizes_name():
+    assert slugify("Layer 1 (L1)") == "layer-1"
+
+
+def test_schema_defaults_are_independent():
+    latest = Latest(date="2025-01-01", scores=Scores(global_=0, liquidite=0, opportunite=0))
+    a = CryptoSummary(id=1, symbol="a", name="A", sectors=[], latest=latest)
+    b = CryptoSummary(id=2, symbol="b", name="B", sectors=[], latest=latest)
+    a.category_names.append("foo")
+    assert b.category_names == []
+
+
+def test_get_coin_categories(monkeypatch):
+    client = CoinGeckoClient(api_key=None)
+
+    def fake_request(self, path, params=None):
+        assert path == "/coins/bitcoin"
+        return DummyResp({"categories": ["Layer 1 (L1)", "Payments"]})
+
+    monkeypatch.setattr(CoinGeckoClient, "_request", fake_request)
+    cats = client.get_coin_categories("bitcoin")
+    assert cats == ["Layer 1 (L1)", "Payments"]
+
+
+def test_etl_and_api_expose_categories(monkeypatch, tmp_path):
+    TestingSessionLocal = _setup_db(tmp_path)
+    monkeypatch.setattr(run_module, "SessionLocal", TestingSessionLocal)
+
+    class StubClient:
+        def get_markets(self, *, vs, per_page, page):
+            return [
+                {
+                    "id": "bitcoin",
+                    "symbol": "btc",
+                    "name": "Bitcoin",
+                    "current_price": 1.0,
+                    "market_cap": 2.0,
+                    "total_volume": 3.0,
+                    "market_cap_rank": 1,
+                    "price_change_percentage_24h": 4.0,
+                }
+            ]
+
+        def get_categories_list(self):
+            return [{"category_id": "layer-1", "name": "Layer 1 (L1)"}]
+
+        def get_coin_categories(self, coin_id: str):
+            assert coin_id == "bitcoin"
+            return ["Layer 1 (L1)", "Unmapped"]
+
+    run_module.run_etl(client=StubClient(), budget=None)
+
+    main_module.app.dependency_overrides[get_session] = lambda: TestingSessionLocal()
+    client = TestClient(main_module.app)
+    resp = client.get("/api/coins/bitcoin/categories")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["category_names"] == ["Layer 1 (L1)", "Unmapped"]
+    assert data["category_ids"] == ["layer-1", "unmapped"]
+    resp2 = client.get("/api/markets/top?limit=1&vs=usd")
+    assert resp2.status_code == 200
+    item = resp2.json()["items"][0]
+    assert item["category_ids"] == ["layer-1", "unmapped"]
+    resp3 = client.get("/api/price/bitcoin")
+    assert resp3.status_code == 200
+    data3 = resp3.json()
+    assert data3["category_ids"] == ["layer-1", "unmapped"]
+
+
+def test_etl_skips_category_fetch_if_recent(monkeypatch, tmp_path):
+    TestingSessionLocal = _setup_db(tmp_path)
+    monkeypatch.setattr(run_module, "SessionLocal", TestingSessionLocal)
+
+    class StubClient:
+        def __init__(self) -> None:
+            self.cat_calls = 0
+
+        def get_markets(self, *, vs, per_page, page):
+            return [
+                {
+                    "id": "bitcoin",
+                    "symbol": "btc",
+                    "name": "Bitcoin",
+                    "current_price": 1.0,
+                    "market_cap": 2.0,
+                    "total_volume": 3.0,
+                    "market_cap_rank": 1,
+                    "price_change_percentage_24h": 4.0,
+                }
+            ]
+
+        def get_categories_list(self):
+            return []
+
+        def get_coin_categories(self, coin_id: str):
+            self.cat_calls += 1
+            return []
+
+    client = StubClient()
+    run_module.run_etl(client=client, budget=None)
+    assert client.cat_calls == 1
+    run_module.run_etl(client=client, budget=None)
+    assert client.cat_calls == 1

--- a/tests/test_etl.py
+++ b/tests/test_etl.py
@@ -119,9 +119,20 @@ def test_run_etl_tracks_actual_calls(monkeypatch, tmp_path, caplog):
         def set(self, key: str, value: str) -> None:
             self.data[key] = value
 
+    class DummyCoinsRepo:
+        def __init__(self, session) -> None:  # pragma: no cover - trivial
+            pass
+
+        def upsert(self, rows) -> None:  # pragma: no cover - trivial
+            pass
+
+        def get_categories_with_timestamp(self, coin_id):  # pragma: no cover - trivial
+            return [], [], None
+
     monkeypatch.setattr(run_module, "SessionLocal", lambda: DummySession())
     monkeypatch.setattr(run_module, "PricesRepo", DummyPricesRepo)
     monkeypatch.setattr(run_module, "MetaRepo", DummyMetaRepo)
+    monkeypatch.setattr(run_module, "CoinsRepo", DummyCoinsRepo)
 
     class PagedClient:
         def __init__(self) -> None:
@@ -199,9 +210,20 @@ def test_run_etl_downgrades_per_page_on_4xx(monkeypatch, tmp_path, caplog):
         def set(self, key: str, value: str) -> None:
             self.data[key] = value
 
+    class DummyCoinsRepo:
+        def __init__(self, session) -> None:  # pragma: no cover - trivial
+            pass
+
+        def upsert(self, rows) -> None:  # pragma: no cover - trivial
+            pass
+
+        def get_categories_with_timestamp(self, coin_id):  # pragma: no cover - trivial
+            return [], [], None
+
     monkeypatch.setattr(run_module, "SessionLocal", lambda: DummySession())
     monkeypatch.setattr(run_module, "PricesRepo", DummyPricesRepo)
     monkeypatch.setattr(run_module, "MetaRepo", DummyMetaRepo)
+    monkeypatch.setattr(run_module, "CoinsRepo", DummyCoinsRepo)
 
     class FallbackClient:
         def __init__(self) -> None:
@@ -284,9 +306,20 @@ def test_run_etl_stops_when_budget_exhausted(monkeypatch, tmp_path):
         def set(self, key: str, value: str) -> None:
             self.data[key] = value
 
+    class DummyCoinsRepo:
+        def __init__(self, session) -> None:  # pragma: no cover - trivial
+            pass
+
+        def upsert(self, rows) -> None:  # pragma: no cover - trivial
+            pass
+
+        def get_categories_with_timestamp(self, coin_id):  # pragma: no cover - trivial
+            return [], [], None
+
     monkeypatch.setattr(run_module, "SessionLocal", lambda: DummySession())
     monkeypatch.setattr(run_module, "PricesRepo", DummyPricesRepo)
     monkeypatch.setattr(run_module, "MetaRepo", DummyMetaRepo)
+    monkeypatch.setattr(run_module, "CoinsRepo", DummyCoinsRepo)
 
     class PagedClient:
         def __init__(self) -> None:


### PR DESCRIPTION
## Summary
- fetch and store coin categories from CoinGecko
- expose categories through API and new endpoint
- display category badges in the frontend table

## Testing
- `ruff check backend && black backend`
- `pytest`
- `node tests/test_frontend.js`


------
https://chatgpt.com/codex/tasks/task_e_68bed23f888c8327ab9354fee24a434e