### PR TITLE
docs: describe asset intelligence coverage

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,27 @@
-MIT License
+Proprietary License
 
-Copyright (c) 2025 Tomp0uce
+Copyright © 2025 Tokenlysis. All rights reserved.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+This software and its source code are proprietary to Tokenlysis.
+Unauthorized copying, distribution, modification, public display, or use of this software, in whole or in part, is strictly prohibited without prior written permission from Tokenlysis.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+Permitted Use
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+You may view, clone, and fork this repository for personal and non-commercial evaluation purposes only.
+
+Any commercial use, redistribution, sublicensing, or integration into other software or services is strictly prohibited unless an explicit written agreement has been granted by Tokenlysis.
+
+Restrictions
+
+You may not:
+
+Copy, modify, or distribute the software for commercial purposes.
+
+Sell, license, or otherwise commercialize any part of this software.
+
+Use the software in a way that competes with or substitutes the services offered by Tokenlysis.
+
+Liability
+
+This software is provided "as is," without warranty of any kind, express or implied.
+In no event shall Tokenlysis be liable for any claim, damages, or other liability arising from the use of the software.

--- a/README.md
+++ b/README.md
@@ -1,148 +1,206 @@
 # Tokenlysis
 
-Tokenlysis is a cryptocurrency scoring platform. The current proof of concept fetches a configurable top ``N`` assets (50 by default) from CoinGecko, computes **Liquidity** and **Opportunity** scores and aggregates them into a global score refreshed daily.
+Tokenlysis is a FastAPI-based cryptocurrency ranking proof of concept. It ingests a configurable top ``N`` assets (50 by default) from CoinGecko, stores both the latest snapshot and historical prices in SQLite and serves a lightweight dashboard written in vanilla JavaScript.
 
-The long‑term goal is to rank more than 1,000 crypto-assets and highlight 100 trending tokens outside the top market-cap list. Additional categories and features will arrive in the MVP phase.
+> ⚠️ **Proprietary Notice**  
+> This project is the proprietary software of **Tokenlysis**.  
+> It is **not open source**.  
+> You may view or fork the repository for **personal and non-commercial evaluation purposes only**.  
+> Any commercial use, redistribution, or modification requires prior written permission from Tokenlysis.
 
-For a full overview of features and architecture, see the [functional specifications](Functional_specs.md).
+The long-term roadmap is to analyse more than 1,000 assets with additional thematic categories and richer analytics. The [functional specifications](Functional_specs.md) capture the full target scope and future milestones.
 
-## Overview
+## Current Capabilities
 
-- **Universe**: configurable top ``N`` assets (default 50) from CoinGecko *(MVP: top 1000 + 100 trending)*.
-- **Update schedule**: data is refreshed every 12 hours.
-- **Startup**: fetch live data when the database isn't bootstrapped, otherwise load the bundled seed.
-- **Scores**: Liquidity, Opportunity and Global *(MVP: six categories: Community, Liquidity, Opportunity, Security, Technology, Tokenomics).* 
+- **Universe** – configurable top ``N`` assets (default 50) fetched from CoinGecko.
+- **Scores** – Liquidity, Opportunity and a derived Global score computed from CoinGecko market data.
+- **Refresh cadence** – background ETL runs every 12 hours (configurable with `REFRESH_GRANULARITY`).
+- **Persistence** – SQLite keeps the latest market snapshot (`latest_prices`), historical snapshots (`prices`) and service metadata (`meta`).
+- **Categories** – CoinGecko categories are cached per asset and refreshed every 24 hours.
+- **Seed fallback** – when live data is unavailable the startup sequence loads a bundled seed fallback (`backend/app/seed/top20.json`) if `USE_SEED_ON_FAILURE` is enabled.
+- **CoinGecko budget** – optional persisted call counter throttles requests according to `CG_MONTHLY_QUOTA`.
 
-### Status
+### API Surface
 
-| Feature | Implemented | Planned |
-| ------- | ----------- | ------- |
-| Configurable top N (default 50) | ✅ | Top 1000 + 100 trending |
-| Liquidity & Opportunity scores + Global | ✅ | Six categories with custom weights |
-| Refresh every 12 hours | ✅ | DB + daily snapshots |
-| Static frontend table | ✅ | Rich charts & filtering |
-| `/version` endpoint | ✅ | Auth & watchlists |
-| Seed fallback controlled by `USE_SEED_ON_FAILURE` | ✅ | Quotas & rate limiting |
+| Endpoint | Description |
+| -------- | ----------- |
+| `GET /api/markets/top` | Latest market snapshots limited to ``limit`` (clamped to ``[1, CG_TOP_N]``) for the `usd` quote. |
+| `GET /api/price/{coin_id}` | Latest market snapshot for a single asset or `404` when unknown. |
+| `GET /api/coins/{coin_id}/categories` | Cached CoinGecko category names and identifiers for an asset. |
+| `GET /api/diag` | Operational diagnostics: CoinGecko plan, effective base URL, refresh interval, last ETL metadata, coin quota usage and data source. |
+| `GET /api/last-refresh` | Shortcut exposing the most recent ETL timestamp. |
+| `GET /healthz` / `GET /readyz` | Liveness and readiness endpoints used by container health checks. |
+| `GET /version` / `GET /api/version` | Semantic build/version string sourced from `APP_VERSION` or Git metadata. |
+| `GET /info` | Build metadata (version, git commit and build timestamp) for troubleshooting. |
+
+### Frontend Dashboard
+
+- Static HTML + vanilla JavaScript served from ``/`` by FastAPI.
+- Fetches `/api/markets/top?limit=20&vs=usd` on load and renders a sortable table.
+- Displays CoinGecko categories as badges with overflow counters beyond three categories.
+- Queries `/api/diag` to display a banner whenever the service runs on the CoinGecko demo plan.
+- Includes a retry affordance on fetch errors and shows the last refresh timestamp and data source.
+
+## Asset Intelligence Reference
+
+The reference dashboard shared for Tokenlysis highlights the information that must be surfaced for every cryptocurrency, even if the final UI differs from the mock-up. Each asset view aggregates the following insights:
+
+### Market intelligence & scores
+- Score total dynamique combining daily refreshed thematic KPIs into a single gauge.
+- Score fondamental emphasising news, ETF/regulation events and Google Trends momentum.
+- Market overview cards for spot price, dominance, market capitalisation, volume, supply and 24 h change.
+- Categories and themes surfaced as badges so users can explore comparable assets rapidly.
+
+### Communauté & sentiment
+- Abonnés Twitter, Telegram members, Reddit subscribers and Discord population updated daily.
+- YouTube audience growth, newsletter reach and community engagement rate evolution.
+- Google Trends watchlist per asset with alerts on breakout interest.
+
+### Liquidité & DeFi depth
+- Total Value Locked (TVL) trendlines and protocol breakdowns alongside on-chain dominance.
+- Exchange coverage including trading pairs, liquidity score, order book depth and fiat on-ramp availability.
+
+### Opportunité & momentum
+- RSI 14 j, volume acceleration, breakout detection and volatility clustering signals.
+- Whale transaction monitoring, funding rate shifts and seasonality versus Bitcoin/Ethereum benchmarks.
+
+### Sécurité & technologie
+- Audit coverage, bug bounty programmes, insurance partnerships and incident history.
+- GitHub activity heatmaps (commits, contributors, releases) and infrastructure redundancy indicators.
+
+### Tokenomics & distribution
+- Emission schedule, inflation rate, burn events and staking ratio tracking.
+- Unlock calendar, treasury allocation transparency and whale concentration metrics.
+
+## ETL & Data Management
+
+1. Resolve configuration (CoinGecko base URL, throttle, API key, quota).
+2. Fetch market data via `CoinGeckoClient` with per-call throttling and retry handling.
+3. Persist latest snapshots and append to the historical table within a single transaction.
+4. Refresh category assignments when the cached value is older than 24 hours, falling back to cached slugs.
+5. Update metadata (`last_refresh_at`, `last_etl_items`, `data_source`) and store the monthly call count when a budget file is configured.
+6. On network failures, raise `DataUnavailable` so the caller can trigger the seed fallback and mark the dataset as stale.
+
+The ETL runs on startup and then loops in the background according to `REFRESH_GRANULARITY`. It shares a persisted budget (`BUDGET_FILE`) with the API so the diagnostic endpoint can show quota consumption.
 
 ## Scoring Model
 
+The proof of concept ships with two computed categories and a derived global score:
+
 ### Liquidity
-- Metrics: 24h trading volume (45%), market capitalization (35%), exchange listings (20%).
-- Method: logarithmic scaling and percentile normalization.
+- Metrics: 24 h trading volume (45 %), market capitalization (35 %), exchange listings (20 %).
+- Method: logarithmic scaling and percentile normalisation.
 
 ### Opportunity
-- Metrics: 14‑day RSI (60%) and day‑over‑day volume change (40%).
-- Method: RSI inverted above 70 to reward oversold assets; volume change normalized on a 0‑100 scale.
+- Metrics: 14-day RSI (60 %) and day-over-day volume change (40 %).
+- Method: RSI values above 70 are inverted to reward oversold assets; volume change is normalised to a 0–100 scale.
 
-### Community
-- Metrics: Twitter followers (50%), 30‑day follower growth (30%), combined Discord/Reddit activity (20%).
+### Global
+- Simple average of available category scores (ignores missing components).
 
-### Security
-- Metrics: number of completed audits (50%), network decentralization (30%), days since last major incident (20%).
-
-### Technology
-- Metrics: commits over the last 3 months (60%), active contributors (40%).
-
-### Tokenomics
-- Metrics: supply distribution (40%), inflation rate (30%), vesting/unlock schedule (30%).
-
-## Development Phases
-
-### POC
-- [x] Liquidity scoring
-- [x] Opportunity scoring
-- [x] Global score aggregation
-- [x] Mock ETL generating sample data
-- [x] REST API for `/ranking`, `/asset/{id}` and `/history/{id}`
-- [x] Static frontend table served by the backend
-- [x] Docker Compose setup for backend and frontend (deployable on Synology NAS)
-
-### MVP
-- [ ] Community scoring
-- [ ] Security scoring
-- [ ] Technology scoring
-- [ ] Tokenomics scoring
-- [ ] Trending asset detection
-- [ ] Persistent PostgreSQL storage
-- [ ] User-defined weighting UI
-- [ ] Interactive charts and comparisons
-
-### EVT
-- [ ] User accounts, authentication and watchlists
-- [ ] Worker queue, caching layer and API rate limiting
-- [ ] Historical score charts with price overlays and CSV export
-- [ ] CI/CD pipeline with staging environment
-- [ ] 80 %+ test coverage and load testing
+Roadmap categories (Community, Security, Technology, Tokenomics) remain part of the MVP backlog and are documented in the functional specifications.
 
 ## Architecture
 
-1. **ETL** – Python scripts pull data from external APIs and compute daily metrics and scores.
-2. **API** – A FastAPI application serves the scores and historical series.
-3. **Frontend** – A minimal HTML/JS client displays a table of assets. Future versions will add filtering and charts.
+1. **ETL runner** – Python task fetching CoinGecko markets, refreshing category metadata and writing to SQLite.
+2. **API backend** – FastAPI application exposing public endpoints under `/api`, diagnostics, health probes and static assets under `/`.
+3. **Persistence layer** – SQLAlchemy ORM models for coins, latest prices, historical prices and metadata.
+4. **Frontend** – Static HTML/vanilla JS table bundled inside the repository and served by FastAPI.
+5. **Call budget service** – Optional JSON-backed counter used to enforce the CoinGecko monthly quota and surface usage in diagnostics.
+6. **Logging** – Structured JSON logs for outbound CoinGecko calls and contextual logs for ETL execution paths.
+
+## Development Phases
+
+### Proof of Concept (delivered)
+- [x] Liquidity and Opportunity scoring with global aggregation.
+- [x] CoinGecko ETL with persisted snapshots, cached categories and seed fallback.
+- [x] REST API for markets, price detail, categories, diagnostics, health and version.
+- [x] Static dashboard delivered by the backend.
+- [x] Docker Compose setup for backend + frontend (deployable on Synology NAS).
+
+### Minimum Viable Product (planned)
+- [ ] Add Community, Security, Technology and Tokenomics scores.
+- [ ] Detect 100 trending assets outside the top 1,000.
+- [ ] Introduce persistent PostgreSQL storage and background workers for heavier jobs.
+- [ ] Provide basic charts and user-defined weighting UI on the frontend.
+- [ ] Improve observability and automated alerting around ETL freshness.
+
+### Engineering Validation Test (future)
+- **Market intelligence & scores**
+  - [ ] Score total dynamique consolidating every category into a dynamic asset scorecard.
+  - [ ] Score fondamental with curated news timeline, ETF coverage and macro narrative tracking.
+  - [ ] Automated category and theme explorer tying comparable assets together.
+- **Community analytics & sentiment**
+  - [ ] Abonnés Twitter, Telegram, Reddit, Discord and YouTube dashboards with alerting thresholds.
+  - [ ] Google Trends and social sentiment overlay to capture community momentum shifts.
+  - [ ] Newsletter, influencer and media coverage bench-marking per asset.
+- **Liquidity & DeFi depth**
+  - [ ] Total Value Locked (TVL) history with protocol granularity and dominance ratios.
+  - [ ] Order book depth, exchange quality scoring and fiat/stablecoin on-ramp visibility.
+  - [ ] Capital flow indicators such as exchange inflow/outflow, stablecoin share and DeFi lock-up tracking.
+- **Opportunité & trading signals**
+  - [ ] RSI 14 j, breakout detection, volatility regime classification and funding rate direction.
+  - [ ] Volume acceleration, whale transaction alerts and derivative open-interest monitors.
+  - [ ] Seasonal performance, correlation clusters and relative strength versus benchmarks.
+- **Sécurité & technologie**
+  - [ ] Audit registry integration, bug bounty coverage and incident response tracking.
+  - [ ] GitHub velocity metrics (commits, contributors, releases) with quality scoring.
+  - [ ] Node distribution, infrastructure redundancy and compliance controls.
+- **Tokenomics & supply distribution**
+  - [ ] Unlock and vesting calendar with alerting and impact scoring.
+  - [ ] Inflation, burn schedule, staking ratio and yield analytics.
+  - [ ] Treasury allocation visibility, whale concentration and token distribution monitoring.
 
 ## Development
 
 ### Requirements
 
 - Python 3.11+
-- Install dependencies:
+- Install backend dependencies:
   ```bash
   pip install -r backend/requirements.txt
   ```
 
-### Running
+### Running Locally
 
 ```bash
 uvicorn backend.app.main:app --reload
 ```
 
-The frontend is served statically by the API under `/` while the REST endpoints
-are exposed under `/api`.
+The frontend is served statically under `/` while REST endpoints are available under `/api`.
 
-Set `APP_VERSION` when launching locally so the interface displays the
-expected version:
+Set `APP_VERSION` when launching locally so the interface displays the expected version:
 
 ```bash
 APP_VERSION=1.2.3 uvicorn backend.app.main:app --reload
 ```
 
-#### Configuration
+### Configuration
 
-Copy `.env.example` to `.env` and adjust the values as needed. This file holds sensitive settings such as API keys and database passwords. Keep it outside version control (it is ignored by `.gitignore`) and restrict access on your NAS, for example with `chmod 600 .env`.
+Copy `.env.example` to `.env` and adjust the values as needed. The file contains sensitive settings such as API keys and database credentials; keep it outside version control and restrict access on your NAS (for example with `chmod 600 .env`).
+
 Runtime behaviour can be tweaked with environment variables:
 
-- `CORS_ORIGINS` – comma-separated list of allowed origins (default:
-  `http://localhost`)
-- `CG_TOP_N` – number of assets fetched from CoinGecko (default: `20`)
-- `CG_DAYS` – number of days of history to retrieve (default: `14`)
-- `CG_MONTHLY_QUOTA` – maximum CoinGecko API calls per month (default: `10000`)
-- `CG_PER_PAGE_MAX` – preferred page size for `/coins/markets` calls (default: `250`)
-- `CG_ALERT_THRESHOLD` – fraction of the monthly quota that triggers a scope
-  reduction (default: `0.7`)
-- `REFRESH_GRANULARITY` – cron-like hint exposed by `/api/diag` (default: `12h`).
-  Changing this value updates the ETL scheduler without restarting the app.
-- `COINGECKO_BASE_URL` – override for the CoinGecko API endpoint (defaults to the
-  public URL or Pro URL based on `COINGECKO_PLAN`)
-- `COINGECKO_API_KEY` – optional API key for CoinGecko
-- `COINGECKO_PLAN` – `demo` (default) or `pro` to select the API header
-- `CG_THROTTLE_MS` – minimum delay in milliseconds between CoinGecko API calls
-- `BUDGET_FILE` – path to the persisted CoinGecko call budget JSON file
-- `DATABASE_URL` – SQLAlchemy database URL
-- `USE_SEED_ON_FAILURE` – fall back to bundled seed data when live ETL fails
-  (default: `true`)
-- `SEED_FILE` – path to the seed data used when `USE_SEED_ON_FAILURE` is
-  enabled (default: `./backend/app/seed/top20.json`)
-- `LOG_LEVEL` – base logging level for application and Uvicorn loggers (default: `INFO`).
-  Accepts an integer or one of
-  `DEBUG`, `INFO`, `WARN`, `WARNING`, `ERROR`, `CRITICAL`, `FATAL` or `NOTSET`.
-  Unknown values fall back to `INFO` with a warning. Use `UVICORN_LOG_LEVEL` or
-  `--log-level` to override server log level separately. CoinGecko client and
-  the ETL emit one-line JSON logs with endpoint and latency fields.
+- `CORS_ORIGINS` – comma-separated list of allowed origins (default: `http://localhost`).
+- `CG_TOP_N` – number of assets fetched from CoinGecko (default: `50`).
+- `CG_DAYS` – number of days of history to retrieve (default: `14`).
+- `CG_MONTHLY_QUOTA` – maximum CoinGecko API calls per month (default: `10000`).
+- `CG_PER_PAGE_MAX` – preferred page size for `/coins/markets` calls (default: `250`).
+- `CG_ALERT_THRESHOLD` – fraction of the monthly quota that triggers a scope reduction (default: `0.7`).
+- `CG_THROTTLE_MS` – minimum delay in milliseconds between CoinGecko API calls (default: `150`, raised to 2100 for the demo plan).
+- `REFRESH_GRANULARITY` – cron-like hint exposed by `/api/diag` (default: `12h`); changing this value updates the ETL loop without restarting the app.
+- `COINGECKO_BASE_URL` – override for the CoinGecko API endpoint (defaults to the public or pro URL based on `COINGECKO_PLAN`).
+- `COINGECKO_API_KEY` / `coingecko_api_key` – optional API key for CoinGecko.
+- `COINGECKO_PLAN` – `demo` (default) or `pro` to select the API header name.
+- `BUDGET_FILE` – path to the persisted CoinGecko call budget JSON file.
+- `DATABASE_URL` – SQLAlchemy database URL (defaults to `sqlite:///./tokenlysis.db`).
+- `USE_SEED_ON_FAILURE` – fall back to the bundled seed data when live ETL fails (default: `true`).
+- `SEED_FILE` – path to the seed data used when `USE_SEED_ON_FAILURE` is enabled (default: `./backend/app/seed/top20.json`).
+- `LOG_LEVEL` – base logging level for application and Uvicorn loggers (default: `INFO`). Accepts an integer or one of `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`, `FATAL`, `NOTSET`. Unknown values fall back to `INFO` with a warning. Use `UVICORN_LOG_LEVEL` or `--log-level` to override the server log level separately.
 
 #### Persistence (NAS)
 
-When deploying on a Synology NAS, mount persistent volumes so the database and
-budget survive container restarts:
+When deploying on a Synology NAS, mount persistent volumes so the database and budget survive container restarts:
 
 ```
 /volume1/docker/tokenlysis/data ↔ /data
@@ -152,78 +210,32 @@ The `.env.example` illustrates the host paths to persist data:
 
 - `DATABASE_URL=sqlite:////volume1/docker/tokenlysis/data/tokenlysis.db`
 - `BUDGET_FILE=/volume1/docker/tokenlysis/data/budget.json`
-These map inside the container to `/data`.
+
 Ensure the container user has write permissions on the host directories.
 
-Do **not** define environment variables with empty values. If a value is not
-needed, remove the variable or comment it out in `.env`. On Synology, delete the
-variable from the UI instead of leaving the field blank. Quotes around values
-(e.g. `LOG_LEVEL="INFO"`) are ignored.
+Do **not** define environment variables with empty values. If a value is not needed, remove the variable or comment it out in `.env`. On Synology, delete the variable from the UI instead of leaving the field blank. Quotes around values (e.g. `LOG_LEVEL="INFO"`) are ignored. Boolean variables accept `true/false/1/0/yes/no/on/off` (case-insensitive, surrounding whitespace allowed). Empty or unrecognised values fall back to their defaults. Integer variables behave similarly: empty strings use the default and invalid numbers raise an explicit error.
 
-Boolean variables accept `true/false/1/0/yes/no/on/off` (case-insensitive, surrounding
-whitespace allowed). Empty or unrecognised values fall back to their defaults.
-Integer variables behave similarly: empty strings use the default and invalid numbers
-raise an explicit error.
+The ETL fetches market data using CoinGecko coin IDs. During development the seed assets (`C1`, `C2`, …) are mapped to real CoinGecko IDs through `backend/app/config/seed_mapping.py`.
 
-The ETL fetches market data using CoinGecko's coin IDs. During development the
-seed assets (`C1`, `C2`, …) are mapped to real CoinGecko IDs through
-`backend/app/config/seed_mapping.py`.
+### Deployment on Synology NAS (POC)
 
-### Health & Diagnostics
-
-- `GET /healthz` – returns DB connectivity, bootstrap status and last refresh time
-- `GET /readyz` – readiness check for the web process (`{"ready": true}`)
-- `GET /api/markets/basic` – minimal market data fallback
-- `GET /api/diag` – debug info: plan, granularity, last refresh, ETL rows, call budget
-- `GET /version` – application version (`{"version": "<hash>"}`)
-
-### Public API
-
-- `GET /api/markets/top` – top assets (`limit` clamped to `[1, CG_TOP_N]`, `vs` must be `usd`),
-  returns `{ "items": [...], "last_refresh_at": "...", "stale": bool, "data_source": "api|seed" }`
-
-### Synology NAS Deployment (POC)
-
-The following steps describe how to deploy Tokenlysis on a Synology NAS using
-the local source code.
-
-1. **Install Container Manager** – from the Synology Package Center install the
-   *Container Manager* application (formerly called *Docker*).
-2. **Clone the project** – obtain the Tokenlysis repository on your NAS, e.g.:
-
+1. **Install Container Manager** – from the Synology Package Center install the *Container Manager* application (formerly *Docker*).
+2. **Clone the project** – obtain the Tokenlysis repository on your NAS:
    ```bash
    git clone https://github.com/Tomp0uce/Tokenlysis.git
    cd Tokenlysis
-   ```
-
-   Create a `.env` file from the example and secure it on the NAS:
-
-   ```bash
    cp .env.example .env
    chmod 600 .env
    ```
-
-3. **Create the project** – in **Container Manager**, go to **Project** →
-   **Create** and select the `docker-compose.yml` file from the cloned folder.
-   Add `docker-compose.synology.yml` as an additional compose file so the image
-   is built locally. When defining environment variables in the Synology UI,
-   never leave a value empty. If you don't have a value, remove the variable
-   instead of leaving it blank. Supported boolean values are `true`, `false`,
-   `1`, `0`, `yes`, `no`, `on` and `off` (case-insensitive); an empty value is
-   treated as unset and defaults are applied.
+3. **Create the project** – in **Container Manager**, go to **Project → Create** and select `docker-compose.yml`. Add `docker-compose.synology.yml` as an override so the image is built locally. When defining environment variables in the Synology UI, never leave a value empty. If you do not have a value, remove the variable instead of leaving it blank. Supported boolean values are `true`, `false`, `1`, `0`, `yes`, `no`, `on` and `off` (case-insensitive); an empty value is treated as unset and defaults are applied.
 4. **Build and start** – from the NAS terminal run:
-
    ```bash
    APP_VERSION=1.0.123 \
    docker compose -f docker-compose.yml -f docker-compose.synology.yml build --no-cache
    docker compose -f docker-compose.yml -f docker-compose.synology.yml up -d
    ```
-
-   The build step injects the desired version into the image (defaults to
-   `dev`). The subsequent `up` starts the container. A healthcheck inside the
-   container polls `http://localhost:8000/readyz` every 30 seconds.
-5. **Access the app** – once running the interface is available at
-   `http://<NAS_IP>:8002`.
+   The build step injects the desired version into the image (defaults to `dev`). The subsequent `up` starts the container. A healthcheck inside the container polls `http://localhost:8000/readyz` every 30 seconds.
+5. **Access the app** – the interface is available at `http://<NAS_IP>:8002` once the container reports healthy.
 
 #### Updating
 
@@ -234,30 +246,23 @@ docker compose -f docker-compose.yml -f docker-compose.synology.yml build --no-c
 docker compose -f docker-compose.yml -f docker-compose.synology.yml up -d
 ```
 
-### Testing
+## Testing
 
 ```bash
 pytest
 ```
 
-### Image Version
+## Image Versioning
 
-Docker images embed a version string that defaults to the number of commits in
-the repository. The value is passed at build time through the `APP_VERSION`
-build argument and is exposed inside the container as the `APP_VERSION`
-environment variable. The same value is also written to the
-`org.opencontainers.image.version` OCI label for traceability.
+Docker images embed a version string that defaults to the number of commits in the repository. The value is passed at build time through the `APP_VERSION` build argument and exposed inside the container as the `APP_VERSION` environment variable. The same value is also written to the `org.opencontainers.image.version` OCI label for traceability.
 
-GitHub Actions sets the value to `1.0.<run_number>` using `github.run_number` and
-injects it with `--build-arg APP_VERSION=${APP_VERSION}` during the build. When
-building locally you can override the version:
+GitHub Actions sets the value to `1.0.<run_number>` using `github.run_number` and injects it with `--build-arg APP_VERSION=${APP_VERSION}` during the build. When building locally you can override the version:
 
 ```bash
 docker build --build-arg APP_VERSION=42 -t tokenlysis:test -f ./Dockerfile .
 ```
 
-To propagate a new version to the dashboard and API, the image must be rebuilt
-with the desired value:
+To propagate a new version to the dashboard and API, rebuild the image with the desired value:
 
 ```bash
 APP_VERSION=1.2.3 \
@@ -265,14 +270,8 @@ docker compose -f docker-compose.yml -f docker-compose.synology.yml build --no-c
 docker compose -f docker-compose.yml -f docker-compose.synology.yml up -d
 ```
 
-At runtime the container exposes `APP_VERSION` so it can be inspected with
-`docker run --rm tokenlysis:test env | grep APP_VERSION`.
-
-During the build the same value is also written to `frontend/app-version.js`
-so the static dashboard can display the version even if the API is
-unreachable.
+At runtime the container exposes `APP_VERSION` so it can be inspected with `docker run --rm tokenlysis:test env | grep APP_VERSION`. During the build the same value is written to `frontend/app-version.js` so the static dashboard can display the version even if the API is unreachable.
 
 ## License
 
-This project is licensed under the MIT License.
-
+This project is distributed under a proprietary license. See [LICENSE](LICENSE) for full terms and permitted usage.

--- a/backend/app/etl/run.py
+++ b/backend/app/etl/run.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+"""ETL helpers fetching CoinGecko markets and persisting them in SQLite."""
+
 import datetime as dt
 import json
 import logging
@@ -34,6 +36,7 @@ def _fetch_markets(
     per_page_max: int,
     budget: CallBudget | None,
 ) -> tuple[list[dict], int]:
+    """Fetch market pages until the limit is reached while tracking API calls."""
     per_page = min(per_page_max, 250)
     coins: list[dict] = []
     page = 1

--- a/backend/app/services/indicators.py
+++ b/backend/app/services/indicators.py
@@ -2,6 +2,7 @@ from typing import Iterable, List
 
 
 def rsi(prices: Iterable[float], period: int = 14) -> List[float]:
+    """Compute the Relative Strength Index while tolerating short price sequences."""
     prices = list(prices)
     n = len(prices)
     if n < 2:

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -1,6 +1,7 @@
 import { getAppVersion } from './version.js';
 import { extractItems, resolveVersion } from './utils.js';
 
+// ===== Application state & configuration =====
 const API_URL = document.querySelector('meta[name="api-url"]')?.content || '';
 let appVersion = 'unknown';
 export const selectedCategories = [];
@@ -20,6 +21,7 @@ let marketItems = [];
 const boundSortableHeaders = new WeakSet();
 let sortState = { columnIndex: null, direction: 'asc' };
 
+// ===== Formatting helpers =====
 function formatPrice(p) {
   if (p === null || p === undefined) return '';
   if (p >= 1) return p.toFixed(2);
@@ -90,6 +92,7 @@ function renderRows(items) {
   tbody.appendChild(fragment);
 }
 
+// ===== Sorting helpers =====
 function clearSortIndicators() {
   document.querySelectorAll('#cryptos thead th').forEach((th) => {
     th.classList.remove('sort-asc', 'sort-desc');

--- a/frontend/utils.js
+++ b/frontend/utils.js
@@ -1,4 +1,7 @@
+// ===== API response helpers =====
+
 export function extractItems(json) {
+  // Normalise `/api/markets/top` payloads into a flat array for rendering.
   if (Array.isArray(json)) {
     return json;
   }
@@ -9,6 +12,7 @@ export function extractItems(json) {
 }
 
 export function resolveVersion(apiVersion, localVersion) {
+  // Prefer API version strings but fall back to baked-in build metadata.
   if (apiVersion && apiVersion !== 'dev') return apiVersion;
   if (localVersion) return localVersion;
   return 'dev';

--- a/frontend/version.js
+++ b/frontend/version.js
@@ -1,3 +1,5 @@
+// ===== Version resolution helpers =====
+
 export function getAppVersion() {
   try {
     if (import.meta && import.meta.env && import.meta.env.VITE_APP_VERSION) {

--- a/tests/test_documentation_updates.py
+++ b/tests/test_documentation_updates.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import importlib
+import inspect
+from pathlib import Path
+
+
+def _section(content: str, heading: str) -> str:
+    marker = f"### {heading}"
+    if marker not in content:
+        return ""
+    _, _, tail = content.partition(marker)
+    # split until the next level-3 heading to isolate the section body
+    next_heading_index = tail.find("\n### ")
+    body = tail if next_heading_index == -1 else tail[:next_heading_index]
+    return body
+
+
+def test_readme_lists_market_endpoints() -> None:
+    content = Path("README.md").read_text(encoding="utf-8")
+    lowered = content.lower()
+    assert "get /api/price/{coin_id}" in lowered
+    assert "get /api/diag" in lowered
+    assert "seed fallback" in lowered or "fallback seed" in lowered
+
+
+def test_readme_uses_checkboxes_for_phase_status() -> None:
+    content = Path("README.md").read_text(encoding="utf-8")
+    sections: dict[str, str] = {}
+    for chunk in content.split("### ")[1:]:
+        header, _, body = chunk.partition("\n")
+        sections[header.strip()] = body
+
+    poc = sections.get("Proof of Concept (delivered)")
+    assert poc is not None and "- [x]" in poc
+
+    mvp = sections.get("Minimum Viable Product (planned)")
+    assert mvp is not None and "- [ ]" in mvp
+
+    evt = sections.get("Engineering Validation Test (future)")
+    assert evt is not None and "- [ ]" in evt
+
+
+def test_readme_describes_asset_reference_dashboard() -> None:
+    content = Path("README.md").read_text(encoding="utf-8")
+    lowered = content.lower()
+    assert "score total dynamique" in lowered
+    assert "score fondamental" in lowered
+    assert "total value locked (tvl)" in lowered
+    assert "abonnés twitter" in lowered
+    for label in ("communauté", "liquidité", "opportunité", "sécurité", "technologie", "tokenomics"):
+        assert label in lowered
+
+
+def test_functional_specs_outlines_asset_data_coverage() -> None:
+    content = Path("Functional_specs.md").read_text(encoding="utf-8")
+    lowered = content.lower()
+    required_phrases = (
+        "score total dynamique",
+        "score fondamental",
+        "total value locked",
+        "abonnés twitter",
+        "google trends",
+    )
+    for phrase in required_phrases:
+        assert phrase in lowered
+
+
+def test_evt_roadmap_groups_features_by_category() -> None:
+    readme = Path("README.md").read_text(encoding="utf-8")
+    section = _section(readme, "Engineering Validation Test (future)")
+    lowered = section.lower()
+    assert "market intelligence" in lowered
+    assert "community" in lowered
+    assert "liquidity" in lowered
+    assert "sécurité" in lowered
+    assert "tokenomics" in lowered
+    for feature in ("score total dynamique", "score fondamental", "total value locked", "abonnés twitter"):
+        assert f"- [ ]" in section
+        assert feature in lowered
+
+    specs = Path("Functional_specs.md").read_text(encoding="utf-8")
+    evt_section = _section(specs, "Engineering Validation Test (future)")
+    evt_lower = evt_section.lower()
+    assert "market intelligence" in evt_lower
+    assert "community" in evt_lower
+    assert "liquidity" in evt_lower
+    assert "sécurité" in evt_lower
+    assert "tokenomics" in evt_lower
+    for feature in ("score total dynamique", "score fondamental", "total value locked", "abonnés twitter"):
+        assert "- [ ]" in evt_section
+        assert feature in evt_lower
+
+
+def test_functional_specs_describes_current_stack() -> None:
+    content = Path("Functional_specs.md").read_text(encoding="utf-8")
+    lowered = content.lower()
+    assert "vanilla javascript" in lowered or "static html" in lowered
+    assert "sqlite" in lowered
+    assert "background" in lowered and "etl" in lowered
+
+
+def test_readme_contains_proprietary_notice_and_no_mit() -> None:
+    content = Path("README.md").read_text(encoding="utf-8")
+    lowered = content.lower()
+    assert "⚠️ **proprietary notice**" in lowered
+    assert "not open source" in lowered
+    assert "mit license" not in lowered
+
+
+def test_license_is_proprietary() -> None:
+    content = Path("LICENSE").read_text(encoding="utf-8")
+    lowered = content.lower()
+    assert "proprietary license" in lowered
+    assert "copyright © 2025 tokenlysis" in lowered
+    assert "mit license" not in lowered
+
+
+def test_key_docstrings_explain_behaviour() -> None:
+    main_module = importlib.import_module("backend.app.main")
+    doc = inspect.getdoc(main_module.markets_top)
+    assert doc is not None and "clamp" in doc.lower()
+    assert "unsupported vs" in doc.lower()
+
+    indicators = importlib.import_module("backend.app.services.indicators")
+    rsi_doc = inspect.getdoc(indicators.rsi)
+    assert rsi_doc is not None and "relative strength index" in rsi_doc.lower()
+
+
+def test_refresh_interval_docstring_mentions_fallback() -> None:
+    main_module = importlib.import_module("backend.app.main")
+    doc = inspect.getdoc(main_module.refresh_interval_seconds)
+    assert doc is not None
+    lowered = doc.lower()
+    assert "fallback" in lowered
+    assert "12" in doc
+
+
+def test_frontend_main_includes_section_comments() -> None:
+    js = Path("frontend/main.js").read_text(encoding="utf-8")
+    assert "// ===== formatting helpers =====" in js.lower()
+    assert "// ===== sorting helpers =====" in js.lower()


### PR DESCRIPTION
## Summary
- document the per-asset intelligence scope from the design reference in the README and functional specifications, covering market intelligence, community, liquidity, opportunity, security, technology and tokenomics data
- reorganize the Engineering Validation Test roadmap into category-based checklists that highlight score, community, liquidity, trading, security and tokenomics deliverables
- extend the documentation regression suite with checks for the new asset data coverage and roadmap structure

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cef5d108c083279a520654dffdac9f