### PR TITLE
fix: align market table labels and coin logo migration

### DIFF
--- a/backend/alembic/versions/0005_add_coin_logo_url.py
+++ b/backend/alembic/versions/0005_add_coin_logo_url.py
@@ -15,7 +15,7 @@ depends_on = None
 def upgrade() -> None:
     op.add_column(
         "coins",
-        sa.Column("logo_url", sa.String(), nullable=True, server_default=""),
+        sa.Column("logo_url", sa.String(), nullable=True),
     )
 
 


### PR DESCRIPTION
## Summary
- align the market table cell labels with the updated dashboard headers so merged layouts stay conflict-free and currency gaps show an em dash
- add data-label attributes to change columns and reuse a shared formatter to emit `$`/`—` consistently across rows
- extend the frontend integration test to assert the new labels and fallback rendering
- add an Alembic migration for `Coin.logo_url` that keeps the column nullable without a database default so missing logos stay `NULL`

## Testing
- node --test frontend/*.test.js tests/test_frontend.js *(fails locally: SyntaxError “Identifier 'formatDisplayName' has already been declared” from existing frontend suite)*
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d0069671c083278fd16d4af9037f09