### PR TITLE
feat: abbreviate coin metrics and show logo

### DIFF
--- a/frontend/coin.html
+++ b/frontend/coin.html
@@ -13,7 +13,10 @@
     <header class="dashboard-header">
       <div class="brand">
         <a href="./index.html" class="breadcrumb-link">← Retour au classement</a>
-        <h1 id="coin-title">Détails</h1>
+        <h1 id="coin-title" class="coin-title">
+          <img id="coin-logo" class="coin-logo" alt="" hidden>
+          <span id="coin-title-text">Détails</span>
+        </h1>
         <p>Analyse approfondie des métriques et historiques de la crypto sélectionnée.</p>
       </div>
       <button type="button" class="theme-toggle" data-theme-toggle aria-label="Activer le thème sombre">Thème</button>

--- a/frontend/coin.test.js
+++ b/frontend/coin.test.js
@@ -15,6 +15,29 @@ async function loadTestExports() {
   return testExportsPromise;
 }
 
+function setupCoinDom() {
+  const dom = new JSDOM(
+    `<!doctype html><html><head><title>Tokenlysis – Détails</title></head><body>
+      <main>
+        <h1 id="coin-title" class="coin-title">
+          <img id="coin-logo" class="coin-logo" alt="" hidden>
+          <span id="coin-title-text">Détails</span>
+        </h1>
+        <strong id="price-value">—</strong>
+        <small id="price-updated">—</small>
+        <strong id="market-cap-value">—</strong>
+        <strong id="volume-value">—</strong>
+        <div id="categories"></div>
+      </main>
+    </body></html>`,
+    { url: 'http://localhost' },
+  );
+  global.window = dom.window;
+  global.document = dom.window.document;
+  global.localStorage = dom.window.localStorage;
+  return dom;
+}
+
 test('buildHistoricalDataset keeps a shared timeline and nulls invalid values', async () => {
   const { buildHistoricalDataset } = await loadTestExports();
   const points = [
@@ -42,4 +65,69 @@ test('buildHistoricalDataset returns empty arrays when no valid points exist', a
   assert.deepEqual(dataset.price, []);
   assert.deepEqual(dataset.marketCap, []);
   assert.deepEqual(dataset.volume, []);
+});
+
+test('formatUsd abbreviates large values using k$, M$, B$ and T$', async () => {
+  const { formatUsd } = await loadTestExports();
+
+  assert.equal(formatUsd(999), '999 $');
+  assert.equal(formatUsd(1500), '1.5 k$');
+  assert.equal(formatUsd(2_345_000), '2.35 M$');
+  assert.equal(formatUsd(3_456_000_000), '3.46 B$');
+  assert.equal(formatUsd(7_890_000_000_000), '7.89 T$');
+  assert.equal(formatUsd(-12_300_000), '-12.3 M$');
+});
+
+test('renderDetail updates title, metrics and logo with compact values', async () => {
+  const { renderDetail } = await loadTestExports();
+  const dom = setupCoinDom();
+
+  renderDetail({
+    coin_id: 'bitcoin',
+    price: 115_561,
+    market_cap: 2_300_000_000_000,
+    volume_24h: 19_000_000_000,
+    snapshot_at: '2024-01-31T12:30:00Z',
+    category_names: ['Layer 1', 'Payments'],
+    logo_url: 'https://img.test/bitcoin.png',
+  });
+
+  const titleText = dom.window.document.getElementById('coin-title-text').textContent.trim();
+  assert.equal(titleText, 'Bitcoin');
+  assert.equal(dom.window.document.title, 'Tokenlysis – Bitcoin');
+
+  const marketCapText = dom.window.document.getElementById('market-cap-value').textContent;
+  const volumeText = dom.window.document.getElementById('volume-value').textContent;
+  assert.equal(marketCapText, '2.3 T$');
+  assert.equal(volumeText, '19 B$');
+
+  const logo = dom.window.document.getElementById('coin-logo');
+  assert.equal(logo.getAttribute('src'), 'https://img.test/bitcoin.png');
+  assert.equal(logo.getAttribute('alt'), 'Bitcoin');
+  assert.equal(logo.hasAttribute('hidden'), false);
+});
+
+test('renderDetail hides the logo when url is missing and falls back to coin id', async () => {
+  const { renderDetail } = await loadTestExports();
+  const dom = setupCoinDom();
+
+  renderDetail({
+    coin_id: 'my-coin',
+    price: 1,
+    market_cap: 800,
+    volume_24h: null,
+    snapshot_at: '2024-02-01T00:00:00Z',
+    category_names: [],
+    logo_url: '',
+  });
+
+  const titleText = dom.window.document.getElementById('coin-title-text').textContent.trim();
+  assert.equal(titleText, 'My Coin');
+
+  const logo = dom.window.document.getElementById('coin-logo');
+  assert.equal(logo.getAttribute('src'), '');
+  assert.equal(logo.hasAttribute('hidden'), true);
+  assert.equal(logo.getAttribute('alt'), '');
+  const volumeText = dom.window.document.getElementById('volume-value').textContent;
+  assert.equal(volumeText, '—');
 });

--- a/frontend/theme.css
+++ b/frontend/theme.css
@@ -97,6 +97,12 @@ a:hover {
   color: var(--text-primary);
 }
 
+.coin-title {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
 .brand p {
   margin: 0;
   color: var(--text-secondary);
@@ -510,6 +516,11 @@ tbody td {
   object-fit: contain;
   box-shadow: 0 0 0 1px var(--border-subtle);
   background: var(--surface-base);
+}
+
+.coin-title .coin-logo {
+  width: 48px;
+  height: 48px;
 }
 
 .coin-name {


### PR DESCRIPTION
## Summary
- use compact USD formatting with k$, M$, B$ and T$ on the coin detail page
- render the coin logo alongside the title in the detail header
- extend frontend tests covering formatting and DOM updates

## Testing
- node --test frontend/coin.test.js
- node --test frontend/*.test.js
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0186aa2788327872d4b75875176f3