### PR TITLE
feat: synchronize coin history tooltips

### DIFF
--- a/frontend/charting.js
+++ b/frontend/charting.js
@@ -185,6 +185,9 @@ function baseAreaOptions({
   yFormatter,
   tooltipFormatter,
   banding,
+  chartId,
+  chartGroup,
+  events,
 } = {}) {
   const palette = basePalette(colorVar);
   const theme = document?.documentElement?.dataset?.theme || 'light';
@@ -207,17 +210,27 @@ function baseAreaOptions({
   };
   const resolvedYFormatter = wrapFormatter(yFormatter, defaultFormatter);
   const resolvedTooltipFormatter = wrapFormatter(tooltipFormatter, resolvedYFormatter);
+  const chartOptions = {
+    type: 'area',
+    height: 280,
+    toolbar: { show: false },
+    zoom: { enabled: false },
+    selection: { enabled: false },
+    animations: { easing: 'easeinout', speed: 600 },
+    fontFamily: 'Inter, "Segoe UI", sans-serif',
+    foreColor: palette.muted,
+  };
+  if (typeof chartId === 'string' && chartId) {
+    chartOptions.id = chartId;
+  }
+  if (typeof chartGroup === 'string' && chartGroup) {
+    chartOptions.group = chartGroup;
+  }
+  if (events && typeof events === 'object') {
+    chartOptions.events = events;
+  }
   const options = {
-    chart: {
-      type: 'area',
-      height: 280,
-      toolbar: { show: false },
-      zoom: { enabled: false },
-      selection: { enabled: false },
-      animations: { easing: 'easeinout', speed: 600 },
-      fontFamily: 'Inter, "Segoe UI", sans-serif',
-      foreColor: palette.muted,
-    },
+    chart: chartOptions,
     series: [
       {
         name,

--- a/frontend/charting.test.js
+++ b/frontend/charting.test.js
@@ -69,6 +69,39 @@ test('createAreaChart builds smooth area config with shared categories', async (
   await module.destroyTrackedCharts();
 });
 
+test('createAreaChart applies chart id, group and custom events', async () => {
+  const dom = new JSDOM('<!doctype html><html><body></body></html>', { url: 'http://localhost' });
+  global.window = dom.window;
+  global.document = dom.window.document;
+  global.localStorage = dom.window.localStorage;
+  dom.window.ApexCharts = ApexChartsStub;
+  document.documentElement.style.setProperty('--chart-primary', '#654321');
+  document.documentElement.style.setProperty('--text-muted', '#222222');
+  document.documentElement.style.setProperty('--border-subtle', '#cccccc');
+
+  const module = await import('./charting.js');
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const events = {
+    dataPointSelection() {},
+  };
+
+  const chart = await module.createAreaChart(container, {
+    name: 'Volumes',
+    categories: [],
+    data: [],
+    colorVar: '--chart-primary',
+    chartId: 'custom-chart',
+    chartGroup: 'history-group',
+    events,
+  });
+
+  assert.equal(chart.options.chart.id, 'custom-chart');
+  assert.equal(chart.options.chart.group, 'history-group');
+  assert.equal(chart.options.chart.events.dataPointSelection, events.dataPointSelection);
+  await module.destroyTrackedCharts();
+});
+
 test('createAreaChart supports fear-greed banding and custom formatters', async () => {
   const dom = new JSDOM('<!doctype html><html><body></body></html>', { url: 'http://localhost' });
   global.window = dom.window;


### PR DESCRIPTION
## Summary
- sync tooltip selection across the price, market cap and volume charts on the coin page
- track and register history charts so ApexCharts tooltips can be shown/hidden programmatically
- allow createAreaChart to accept chart ids/groups and cover the new behaviors with unit tests

## Testing
- node --test frontend/coin.test.js frontend/charting.test.js
- node --test tests/test_coin_page.js
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0250803d083278bdbb31b5a6cad46