### PR TITLE
feat: support configurable static frontend root

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ Runtime behaviour can be tweaked with environment variables:
 - `USE_SEED_ON_FAILURE` – fall back to the bundled seed data when live ETL fails (default: `true`).
 - `SEED_FILE` – path to the seed data used when `USE_SEED_ON_FAILURE` is enabled (default: `./backend/app/seed/top20.json`).
 - `LOG_LEVEL` – base logging level for application and Uvicorn loggers (default: `INFO`). Accepts an integer or one of `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`, `FATAL`, `NOTSET`. Unknown values fall back to `INFO` with a warning. Use `UVICORN_LOG_LEVEL` or `--log-level` to override the server log level separately.
+- `STATIC_ROOT` – absolute or repository-relative path to the directory containing the static frontend assets. By default FastAPI resolves `backend/app/main.py` two levels up to serve `frontend/`, which means you can start Uvicorn from any working directory. Override this when a deployment copies the assets elsewhere (for example to `/opt/tokenlysis/assets-statiques`).
 
 #### Persistence (NAS)
 

--- a/backend/app/core/settings.py
+++ b/backend/app/core/settings.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any, List
 
 from pydantic import Field, field_validator
@@ -79,6 +80,7 @@ class Settings(BaseSettings):
     BUDGET_FILE: str | None = None
     DATABASE_URL: str | None = None
     SEED_FILE: str = "./backend/app/seed/top20.json"
+    STATIC_ROOT: Path | None = None
     CMC_API_KEY: str | None = None
     CMC_BASE_URL: str | None = None
     CMC_THROTTLE_MS: int = 1000
@@ -133,7 +135,9 @@ class Settings(BaseSettings):
             return int(s)
         return s.upper()
 
-    @field_validator("COINGECKO_API_KEY", "coingecko_api_key", "CMC_API_KEY", mode="before")
+    @field_validator(
+        "COINGECKO_API_KEY", "coingecko_api_key", "CMC_API_KEY", mode="before"
+    )
     @classmethod
     def _empty_api_key(cls, v: Any) -> Any:
         if isinstance(v, str):
@@ -150,6 +154,21 @@ class Settings(BaseSettings):
             return "demo"
         s = str(v).strip().lower()
         return "pro" if s == "pro" else "demo"
+
+    @field_validator("STATIC_ROOT", mode="before")
+    @classmethod
+    def _normalize_static_root(cls, v: Any) -> Path | None:
+        if v is None:
+            return None
+        if isinstance(v, Path):
+            text = str(v).strip()
+            return v if text else None
+        if isinstance(v, str):
+            stripped = v.strip()
+            if stripped == "":
+                return None
+            return Path(stripped).expanduser()
+        return Path(str(v)).expanduser()
 
 
 settings = Settings()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -30,6 +30,20 @@ logger.setLevel(settings.log_level or "INFO")
 app = FastAPI(title="Tokenlysis", version=os.getenv("APP_VERSION", "dev"))
 
 
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _static_directory() -> Path:
+    configured = settings.STATIC_ROOT
+    if configured:
+        path = Path(configured)
+        if not path.is_absolute():
+            return (_repo_root() / path).resolve()
+        return path.expanduser().resolve()
+    return (_repo_root() / "frontend").resolve()
+
+
 @app.get("/info")
 def info() -> dict:
     """Return build metadata so operators can verify deployed artifacts."""
@@ -77,7 +91,9 @@ def _serialize_price(p, details: dict[str, object]) -> dict:
     raw_symbol = details.get("symbol") if details else ""
     symbol = raw_symbol.strip() if isinstance(raw_symbol, str) else ""
     raw_logo = details.get("logo_url") if details else None
-    logo_url = raw_logo.strip() if isinstance(raw_logo, str) and raw_logo.strip() else None
+    logo_url = (
+        raw_logo.strip() if isinstance(raw_logo, str) and raw_logo.strip() else None
+    )
     return {
         "coin_id": p.coin_id,
         "vs_currency": p.vs_currency,
@@ -125,9 +141,7 @@ def markets_top(
         except Exception:  # pragma: no cover - defensive
             pass
     return {
-        "items": [
-            _serialize_price(r, details_map.get(r.coin_id, {})) for r in rows
-        ],
+        "items": [_serialize_price(r, details_map.get(r.coin_id, {})) for r in rows],
         "last_refresh_at": last_refresh_at,
         "data_source": data_source,
         "stale": stale,
@@ -427,7 +441,9 @@ async def startup() -> None:
     asyncio.create_task(etl_loop())
 
 
-app.mount("/", StaticFiles(directory="frontend", html=True), name="static")
+STATIC_DIRECTORY = _static_directory()
+
+app.mount("/", StaticFiles(directory=str(STATIC_DIRECTORY), html=True), name="static")
 
 
 __all__ = ["app", "etl_loop", "refresh_interval_seconds"]

--- a/tests/test_documentation_updates.py
+++ b/tests/test_documentation_updates.py
@@ -24,6 +24,13 @@ def test_readme_lists_market_endpoints() -> None:
     assert "seed fallback" in lowered or "fallback seed" in lowered
 
 
+def test_readme_documents_static_root_setting() -> None:
+    content = Path("README.md").read_text(encoding="utf-8")
+    assert "STATIC_ROOT" in content
+    lowered = content.lower()
+    assert "assets" in lowered or "statique" in lowered
+
+
 def test_readme_uses_checkboxes_for_phase_status() -> None:
     content = Path("README.md").read_text(encoding="utf-8")
     sections: dict[str, str] = {}

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -67,6 +67,24 @@ def test_empty_cors_origins(monkeypatch):
     assert cfg.cors_origins == []
 
 
+def test_static_root_defaults_to_none(monkeypatch):
+    monkeypatch.delenv("STATIC_ROOT", raising=False)
+    cfg = settings_module.Settings()
+    assert cfg.STATIC_ROOT is None
+
+
+def test_static_root_empty_string(monkeypatch):
+    monkeypatch.setenv("STATIC_ROOT", "  ")
+    cfg = settings_module.Settings()
+    assert cfg.STATIC_ROOT is None
+
+
+def test_static_root_env_path(monkeypatch, tmp_path):
+    monkeypatch.setenv("STATIC_ROOT", str(tmp_path))
+    cfg = settings_module.Settings()
+    assert cfg.STATIC_ROOT == tmp_path
+
+
 def test_use_seed_on_failure_empty_is_true(monkeypatch):
     for value in ("", " "):
         monkeypatch.setenv("USE_SEED_ON_FAILURE", value)

--- a/tests/test_static_root.py
+++ b/tests/test_static_root.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import importlib
+import os
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+
+def _reload_main():
+    import backend.app.core.settings as settings_module
+    import backend.app.main as main_module
+
+    importlib.reload(settings_module)
+    return importlib.reload(main_module)
+
+
+def _static_mount(app):
+    for route in app.routes:
+        if getattr(route, "name", None) == "static":
+            return route
+    raise AssertionError("static mount not found")
+
+
+def test_static_root_uses_repo_frontend(monkeypatch):
+    monkeypatch.delenv("STATIC_ROOT", raising=False)
+    main_module = _reload_main()
+    mount = _static_mount(main_module.app)
+    expected = Path(main_module.__file__).resolve().parents[2] / "frontend"
+    assert Path(mount.app.directory) == expected
+    _reload_main()
+
+
+def test_static_root_override(monkeypatch, tmp_path):
+    custom_index = tmp_path / "index.html"
+    custom_index.write_text("<html><body>override</body></html>", encoding="utf-8")
+
+    monkeypatch.setenv("STATIC_ROOT", str(tmp_path))
+    try:
+        main_module = _reload_main()
+        mount = _static_mount(main_module.app)
+        assert Path(mount.app.directory) == tmp_path
+    finally:
+        monkeypatch.delenv("STATIC_ROOT", raising=False)
+        _reload_main()
+
+
+def test_uvicorn_serves_frontend_from_subdirectory(tmp_path):
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    host, port = sock.getsockname()
+    sock.close()
+
+    repo_root = Path(__file__).resolve().parents[1]
+    env = os.environ.copy()
+    pythonpath = env.get("PYTHONPATH")
+    extra_path = str(repo_root)
+    env["PYTHONPATH"] = (
+        extra_path if not pythonpath else os.pathsep.join([extra_path, pythonpath])
+    )
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "uvicorn",
+        "backend.app.main:app",
+        "--host",
+        host,
+        "--port",
+        str(port),
+        "--log-level",
+        "warning",
+        "--lifespan",
+        "off",
+    ]
+
+    proc = subprocess.Popen(
+        cmd,
+        cwd=run_dir,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    url = f"http://{host}:{port}/index.html"
+    deadline = time.time() + 20
+    last_error: Exception | None = None
+    body: bytes | None = None
+    status: int | None = None
+    stdout_data = ""
+    stderr_data = ""
+    try:
+        while time.time() < deadline:
+            if proc.poll() is not None:
+                break
+            try:
+                with urllib.request.urlopen(url, timeout=5) as resp:
+                    body = resp.read()
+                    status = resp.getcode()
+                break
+            except urllib.error.URLError as exc:  # pragma: no cover - retry loop
+                last_error = exc
+                time.sleep(0.2)
+    finally:
+        proc.terminate()
+        try:
+            stdout_data, stderr_data = proc.communicate(timeout=5)
+        except subprocess.TimeoutExpired:  # pragma: no cover - defensive
+            proc.kill()
+            stdout_data, stderr_data = proc.communicate(timeout=5)
+
+    if body is None or status != 200:
+        raise AssertionError(
+            "Uvicorn did not serve index.html"
+            f" (return code={proc.returncode}, last_error={last_error}, stdout={stdout_data}, stderr={stderr_data})"
+        )
+
+    assert b"<!DOCTYPE html" in body or b"<html" in body


### PR DESCRIPTION
## Summary
- resolve the frontend directory relative to backend/app/main.py and honor an optional STATIC_ROOT setting
- add pytest coverage for the new configuration, including a uvicorn smoke test that runs from an alternate working directory
- document the STATIC_ROOT deployment option in the README

## Testing
- pytest
- node --test tests/*.js

------
https://chatgpt.com/codex/tasks/task_e_68d02e90af788327ae01b4b624b40535