### PR TITLE
feat: cache backend version lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,9 @@ Set `APP_VERSION` when launching locally so the interface displays the expected 
 APP_VERSION=1.2.3 uvicorn backend.app.main:app --reload
 ```
 
+When `APP_VERSION` is not set (or equals `dev`), the backend falls back to reading a `VERSION` file located next to the backend
+sources. You can point to a custom location by exporting `VERSION_FILE` before starting the API.
+
 ### Configuration
 
 Copy `.env.example` to `.env` and adjust the values as needed. The file contains sensitive settings such as API keys and database credentials; keep it outside version control and restrict access on your NAS (for example with `chmod 600 .env`).
@@ -217,6 +220,7 @@ Runtime behaviour can be tweaked with environment variables:
 - `DATABASE_URL` – SQLAlchemy database URL (defaults to `sqlite:///./tokenlysis.db`).
 - `USE_SEED_ON_FAILURE` – fall back to the bundled seed data when live ETL fails (default: `true`).
 - `SEED_FILE` – path to the seed data used when `USE_SEED_ON_FAILURE` is enabled (default: `./backend/app/seed/top20.json`).
+- `VERSION_FILE` – path to the file containing the build version when `APP_VERSION` is unset or equals `dev` (default: `./backend/VERSION`).
 - `LOG_LEVEL` – base logging level for application and Uvicorn loggers (default: `INFO`). Accepts an integer or one of `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`, `FATAL`, `NOTSET`. Unknown values fall back to `INFO` with a warning. Use `UVICORN_LOG_LEVEL` or `--log-level` to override the server log level separately.
 
 #### Persistence (NAS)

--- a/tests/test_version_core.py
+++ b/tests/test_version_core.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import importlib
+
+from backend.app.core import version as version_module
+
+
+# T4: lecture standard depuis VERSION_FILE avec cache et rafraîchissement forcé
+def test_get_version_from_file_with_cache(monkeypatch, tmp_path):
+    monkeypatch.delenv("APP_VERSION", raising=False)
+    version_file = tmp_path / "VERSION"
+    version_file.write_text("1.0.0")
+    monkeypatch.setenv("VERSION_FILE", str(version_file))
+    module = importlib.reload(version_module)
+
+    assert module.get_version(force_refresh=True) == "1.0.0"
+
+    version_file.write_text("2.0.0")
+    assert module.get_version() == "1.0.0"
+    assert module.get_version(force_refresh=True) == "2.0.0"
+
+
+def test_get_version_dev_env_missing_file(monkeypatch, tmp_path):
+    monkeypatch.setenv("APP_VERSION", "dev")
+    missing_file = tmp_path / "VERSION"
+    monkeypatch.setenv("VERSION_FILE", str(missing_file))
+    module = importlib.reload(version_module)
+
+    assert module.get_version(force_refresh=True) == "dev"

--- a/tests/test_version_endpoint.py
+++ b/tests/test_version_endpoint.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import importlib
+
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
+from backend.app.core import version as version_module
 from backend.app.db import Base, get_session
 
 
@@ -30,6 +33,8 @@ def _make_client(monkeypatch, tmp_path):
 
 def test_env_version(monkeypatch, tmp_path):
     monkeypatch.setenv("APP_VERSION", "7.7.7")
+    importlib.reload(version_module)
+    version_module.get_version(force_refresh=True)
     client, main_module = _make_client(monkeypatch, tmp_path)
     resp = client.get("/api/version")
     assert resp.status_code == 200
@@ -39,10 +44,11 @@ def test_env_version(monkeypatch, tmp_path):
 
 def test_file_version(monkeypatch, tmp_path):
     monkeypatch.delenv("APP_VERSION", raising=False)
-    monkeypatch.setattr(
-        "backend.app.core.version.REPO_ROOT", tmp_path
-    )
-    (tmp_path / "VERSION").write_text("8.8.8")
+    version_file = tmp_path / "VERSION"
+    version_file.write_text("8.8.8")
+    monkeypatch.setenv("VERSION_FILE", str(version_file))
+    importlib.reload(version_module)
+    version_module.get_version(force_refresh=True)
     client, main_module = _make_client(monkeypatch, tmp_path)
     resp = client.get("/api/version")
     assert resp.status_code == 200
@@ -52,9 +58,9 @@ def test_file_version(monkeypatch, tmp_path):
 
 def test_default_dev(monkeypatch, tmp_path):
     monkeypatch.delenv("APP_VERSION", raising=False)
-    monkeypatch.setattr(
-        "backend.app.core.version.REPO_ROOT", tmp_path
-    )
+    monkeypatch.setenv("VERSION_FILE", str(tmp_path / "VERSION"))
+    importlib.reload(version_module)
+    version_module.get_version(force_refresh=True)
     client, main_module = _make_client(monkeypatch, tmp_path)
     resp = client.get("/api/version")
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- compute the backend repository root relative to the module and allow overriding the VERSION file through an environment variable
- add a cached version lookup with a force-refresh flag for tests and cover the behaviour with new pytest cases
- document how to point the backend to a custom VERSION file location

## Testing
- pytest
- node --test tests/*.js

------
https://chatgpt.com/codex/tasks/task_e_68d0325a0990832790d5e78b4a0932d2