### PR TITLE
fix: restore default VERSION fallback to project root

### DIFF
--- a/backend/app/core/version.py
+++ b/backend/app/core/version.py
@@ -18,6 +18,9 @@ def _resolve_version_file() -> Path:
     version_file_env = os.getenv("VERSION_FILE")
     if version_file_env:
         return Path(version_file_env)
+    repo_parent_version = REPO_ROOT.parent / "VERSION"
+    if repo_parent_version.exists():
+        return repo_parent_version
     return REPO_ROOT / "VERSION"
 
 
@@ -26,8 +29,9 @@ def get_version(*, force_refresh: bool = False) -> str:
 
     Resolution order:
       1) ``APP_VERSION`` environment variable when set and not ``"dev"``
-      2) contents of ``VERSION`` file located next to the backend package
-         (override with ``VERSION_FILE`` environment variable)
+      2) contents of ``VERSION`` file located at the project root (``/app/VERSION``
+         in containers) or next to the backend package when present (override with
+         ``VERSION_FILE`` environment variable)
       3) fallback to ``"dev"``
     """
 

--- a/tests/test_version_core.py
+++ b/tests/test_version_core.py
@@ -27,3 +27,19 @@ def test_get_version_dev_env_missing_file(monkeypatch, tmp_path):
     module = importlib.reload(version_module)
 
     assert module.get_version(force_refresh=True) == "dev"
+
+
+def test_get_version_defaults_to_repo_root_parent(monkeypatch, tmp_path):
+    monkeypatch.delenv("APP_VERSION", raising=False)
+    monkeypatch.delenv("VERSION_FILE", raising=False)
+    module = importlib.reload(version_module)
+
+    backend_dir = tmp_path / "backend"
+    backend_dir.mkdir()
+    version_path = tmp_path / "VERSION"
+    version_path.write_text("9.9.9")
+
+    monkeypatch.setattr(module, "REPO_ROOT", backend_dir, raising=False)
+    monkeypatch.setattr(module, "_VERSION_CACHE", None, raising=False)
+
+    assert module.get_version(force_refresh=True) == "9.9.9"


### PR DESCRIPTION
## Summary
- prefer the project root VERSION file to match the Docker image layout while keeping support for backend-local files
- document the updated resolution order for the VERSION file
- add a regression test proving that the fallback reads from the project root by default

## Testing
- pytest tests/test_version_core.py
- pytest
- node --test tests/*.js

------
https://chatgpt.com/codex/tasks/task_e_68d03630a8cc83278bf31ba6fceef47f