### PR TITLE
feat: add diagnostics debug dashboard

### DIFF
--- a/frontend/debug.html
+++ b/frontend/debug.html
@@ -1,0 +1,171 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="api-url" content="/api">
+  <title>Tokenlysis – Diagnostics</title>
+  <link rel="stylesheet" href="./theme.css">
+  <style>
+    body {
+      font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: var(--color-background, #0f172a);
+      color: var(--color-text, #e2e8f0);
+      margin: 0;
+      padding: 2rem;
+    }
+
+    main.debug-dashboard {
+      max-width: 960px;
+      margin: 0 auto;
+      display: flex;
+      flex-direction: column;
+      gap: 1.5rem;
+    }
+
+    header.debug-header {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+
+    .metric-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      gap: 1.5rem;
+    }
+
+    .metric-card {
+      background: rgba(15, 23, 42, 0.8);
+      border: 1px solid rgba(148, 163, 184, 0.2);
+      border-radius: 12px;
+      padding: 1.25rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+
+    .metric-title {
+      font-size: 1.1rem;
+      font-weight: 600;
+    }
+
+    .metric-values {
+      margin: 0;
+      font-size: 0.95rem;
+      color: var(--color-muted, #94a3b8);
+    }
+
+    .status-pill {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 999px;
+      padding: 0.25rem 0.75rem;
+      font-weight: 600;
+      font-size: 0.95rem;
+    }
+
+    .status-ok {
+      background: rgba(34, 197, 94, 0.15);
+      color: #22c55e;
+    }
+
+    .status-warn {
+      background: rgba(234, 179, 8, 0.15);
+      color: #facc15;
+    }
+
+    .status-error {
+      background: rgba(248, 113, 113, 0.15);
+      color: #f87171;
+    }
+
+    .status-unknown {
+      background: rgba(148, 163, 184, 0.15);
+      color: #cbd5f5;
+    }
+
+    .diag-status {
+      padding: 0.75rem 1rem;
+      border-radius: 12px;
+      font-weight: 600;
+      background: rgba(148, 163, 184, 0.12);
+      border: 1px solid rgba(148, 163, 184, 0.2);
+    }
+
+    section.info-grid {
+      background: rgba(15, 23, 42, 0.8);
+      border: 1px solid rgba(148, 163, 184, 0.2);
+      border-radius: 12px;
+      padding: 1.25rem;
+    }
+
+    section.info-grid dl {
+      margin: 0;
+      display: grid;
+      grid-template-columns: minmax(0, 220px) 1fr;
+      gap: 0.75rem 1rem;
+    }
+
+    section.info-grid dt {
+      font-weight: 600;
+      color: var(--color-muted, #94a3b8);
+    }
+
+    section.info-grid dd {
+      margin: 0;
+    }
+
+    @media (max-width: 600px) {
+      body {
+        padding: 1.5rem;
+      }
+
+      section.info-grid dl {
+        grid-template-columns: 1fr;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main class="debug-dashboard">
+    <header class="debug-header">
+      <div>
+        <h1>Diagnostics Tokenlysis</h1>
+        <p>Suivez les données clés exposées par l'endpoint <code>/api/diag</code>.</p>
+      </div>
+      <div id="diag-status" class="diag-status status-warn">Initialisation…</div>
+    </header>
+
+    <section class="metric-grid" aria-label="Ratios critiques">
+      <article class="metric-card" aria-labelledby="etl-title">
+        <h2 id="etl-title" class="metric-title">Couverture ETL</h2>
+        <p class="metric-values"><strong id="etl-count">—</strong> éléments traités sur <strong id="etl-target">—</strong> attendus</p>
+        <p>Ratio : <span id="etl-ratio" class="status-pill status-unknown">—</span></p>
+      </article>
+      <article class="metric-card" aria-labelledby="budget-title">
+        <h2 id="budget-title" class="metric-title">Budget API</h2>
+        <p class="metric-values">Appels mensuels : <strong id="budget-count">—</strong> / quota <strong id="budget-quota">—</strong></p>
+        <p>Ratio : <span id="budget-ratio" class="status-pill status-unknown">—</span></p>
+      </article>
+    </section>
+
+    <section class="info-grid" aria-label="Métadonnées de la plateforme">
+      <dl>
+        <dt>Source des données</dt>
+        <dd id="diag-source">—</dd>
+        <dt>Plan CoinGecko</dt>
+        <dd id="diag-plan">—</dd>
+        <dt>Base API</dt>
+        <dd id="diag-base-url">—</dd>
+        <dt>Granularité ETL</dt>
+        <dd id="diag-granularity">—</dd>
+        <dt>Dernier rafraîchissement</dt>
+        <dd id="diag-last-refresh">—</dd>
+      </dl>
+    </section>
+  </main>
+  <script type="module" src="./debug.js"></script>
+</body>
+</html>

--- a/frontend/debug.js
+++ b/frontend/debug.js
@@ -1,0 +1,212 @@
+const hasDocument = typeof document !== 'undefined';
+const API_URL = hasDocument
+  ? document.querySelector('meta[name="api-url"]')?.content || ''
+  : '';
+const API_BASE = API_URL.endsWith('/') ? API_URL.slice(0, -1) : API_URL;
+const STATUS_CLASSES = ['status-ok', 'status-warn', 'status-error', 'status-unknown'];
+
+function toFiniteNumber(value) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  const num = Number(value);
+  if (Number.isNaN(num) || !Number.isFinite(num)) {
+    return null;
+  }
+  return num;
+}
+
+function computeRatio(numerator, denominator) {
+  const num = toFiniteNumber(numerator);
+  const den = toFiniteNumber(denominator);
+  if (den === null || den <= 0) {
+    return null;
+  }
+  if (num === null) {
+    return null;
+  }
+  const safeNum = Math.max(num, 0);
+  const ratio = safeNum / den;
+  if (!Number.isFinite(ratio)) {
+    return null;
+  }
+  return ratio;
+}
+
+function classifyEtlRatio(ratio) {
+  if (ratio === null) {
+    return 'unknown';
+  }
+  if (ratio >= 0.95 && ratio <= 1.05) {
+    return 'ok';
+  }
+  if ((ratio >= 0.8 && ratio < 0.95) || (ratio > 1.05 && ratio <= 1.2)) {
+    return 'warn';
+  }
+  return 'error';
+}
+
+function classifyBudgetRatio(ratio) {
+  if (ratio === null) {
+    return 'unknown';
+  }
+  if (ratio <= 0.75) {
+    return 'ok';
+  }
+  if (ratio <= 0.9) {
+    return 'warn';
+  }
+  return 'error';
+}
+
+export function evaluateRatios(diag) {
+  const etlRatio = computeRatio(diag?.last_etl_items, diag?.top_n);
+  const budgetRatio = computeRatio(diag?.monthly_call_count, diag?.quota);
+  return {
+    etl: {
+      ratio: etlRatio,
+      status: classifyEtlRatio(etlRatio),
+    },
+    budget: {
+      ratio: budgetRatio,
+      status: classifyBudgetRatio(budgetRatio),
+    },
+  };
+}
+
+function formatNumber(value) {
+  const num = toFiniteNumber(value);
+  if (num === null) {
+    return '—';
+  }
+  try {
+    return new Intl.NumberFormat('fr-FR').format(Math.round(num));
+  } catch (err) {
+    console.error('formatNumber failed', err);
+    return String(Math.round(num));
+  }
+}
+
+function formatRatio(ratio) {
+  if (ratio === null) {
+    return '—';
+  }
+  const percentage = ratio * 100;
+  if (!Number.isFinite(percentage)) {
+    return '—';
+  }
+  const formatted = percentage.toFixed(1).replace('.', ',');
+  return `${formatted} %`;
+}
+
+function applyStatusClass(element, status) {
+  if (!element) {
+    return;
+  }
+  element.classList.remove(...STATUS_CLASSES);
+  element.classList.add(`status-${status}`);
+}
+
+function updateRatioElement(elementId, metric) {
+  if (!hasDocument) {
+    return;
+  }
+  const element = document.getElementById(elementId);
+  if (!element) {
+    return;
+  }
+  applyStatusClass(element, metric.status);
+  element.textContent = formatRatio(metric.ratio);
+}
+
+function updateNumberElement(elementId, value) {
+  if (!hasDocument) {
+    return;
+  }
+  const element = document.getElementById(elementId);
+  if (!element) {
+    return;
+  }
+  element.textContent = formatNumber(value);
+}
+
+function updateTextElement(elementId, value) {
+  if (!hasDocument) {
+    return;
+  }
+  const element = document.getElementById(elementId);
+  if (!element) {
+    return;
+  }
+  const text = typeof value === 'string' && value.trim() ? value.trim() : '—';
+  element.textContent = text;
+}
+
+function setStatusMessage(message, status) {
+  if (!hasDocument) {
+    return;
+  }
+  const element = document.getElementById('diag-status');
+  if (!element) {
+    return;
+  }
+  element.textContent = message;
+  element.classList.remove('status-ok', 'status-warn', 'status-error');
+  if (status) {
+    element.classList.add(`status-${status}`);
+  }
+}
+
+function renderDiag(diag) {
+  const metrics = evaluateRatios(diag);
+  updateNumberElement('etl-count', diag?.last_etl_items);
+  updateNumberElement('etl-target', diag?.top_n);
+  updateRatioElement('etl-ratio', metrics.etl);
+
+  updateNumberElement('budget-count', diag?.monthly_call_count);
+  updateNumberElement('budget-quota', diag?.quota);
+  updateRatioElement('budget-ratio', metrics.budget);
+
+  updateTextElement('diag-source', diag?.data_source);
+  updateTextElement('diag-plan', diag?.plan);
+  updateTextElement('diag-base-url', diag?.base_url);
+  updateTextElement('diag-granularity', diag?.granularity);
+  updateTextElement('diag-last-refresh', diag?.last_refresh_at);
+}
+
+async function fetchDiag() {
+  const prefix = API_BASE || '';
+  const response = await fetch(`${prefix}/diag`, {
+    headers: { 'Accept': 'application/json' },
+  });
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+  return response.json();
+}
+
+export async function loadDiagnostics() {
+  if (!hasDocument) {
+    return;
+  }
+  try {
+    setStatusMessage('Chargement des diagnostics…', 'warn');
+    const diag = await fetchDiag();
+    renderDiag(diag);
+    setStatusMessage('Diagnostics chargés', 'ok');
+  } catch (error) {
+    console.error('loadDiagnostics failed', error);
+    setStatusMessage('Erreur lors du chargement des diagnostics', 'error');
+  }
+}
+
+if (hasDocument) {
+  const init = () => {
+    loadDiagnostics();
+  };
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init, { once: true });
+  } else {
+    init();
+  }
+}

--- a/tests/debug.test.js
+++ b/tests/debug.test.js
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { evaluateRatios } from '../frontend/debug.js';
+
+function closeTo(value, expected, epsilon = 1e-6) {
+  assert.ok(Math.abs(value - expected) <= epsilon, `${value} not within ${epsilon} of ${expected}`);
+}
+
+test('evaluateRatios returns normalized ratios and statuses', () => {
+  const diag = {
+    last_etl_items: 20,
+    top_n: 20,
+    monthly_call_count: 820,
+    quota: 1000,
+  };
+
+  const metrics = evaluateRatios(diag);
+
+  assert.equal(metrics.etl.status, 'ok');
+  closeTo(metrics.etl.ratio, 1);
+  assert.equal(metrics.budget.status, 'warn');
+  closeTo(metrics.budget.ratio, 0.82);
+});
+
+test('evaluateRatios flags abnormal values and handles empty denominators', () => {
+  const diag = {
+    last_etl_items: 5,
+    top_n: 20,
+    monthly_call_count: 1200,
+    quota: 0,
+  };
+
+  const metrics = evaluateRatios(diag);
+
+  assert.equal(metrics.etl.status, 'error');
+  closeTo(metrics.etl.ratio, 0.25);
+  assert.equal(metrics.budget.status, 'unknown');
+  assert.equal(metrics.budget.ratio, null);
+});


### PR DESCRIPTION
## Summary
- add a diagnostics HTML view that consumes `/api/diag` and displays metadata including the data source
- implement a dedicated frontend module to compute ETL and quota ratios with status-based colour coding
- cover the ratio evaluation logic with a dedicated Node test suite

## Testing
- node --test tests/*.js
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d03bd8949c832780218d04be431448