### PR TITLE
fix: backfill social links when missing

### DIFF
--- a/tests/test_etl.py
+++ b/tests/test_etl.py
@@ -155,12 +155,18 @@ def test_run_etl_tracks_actual_calls(monkeypatch, tmp_path, caplog):
             pass
 
         def get_categories_with_timestamp(self, coin_id):  # pragma: no cover - trivial
-            return [], [], {}, dt.datetime.now(dt.timezone.utc)
+            return [], [], {"__synced__": True}, dt.datetime.now(dt.timezone.utc)
 
     monkeypatch.setattr(run_module, "SessionLocal", lambda: DummySession())
     monkeypatch.setattr(run_module, "PricesRepo", DummyPricesRepo)
     monkeypatch.setattr(run_module, "MetaRepo", DummyMetaRepo)
     monkeypatch.setattr(run_module, "CoinsRepo", DummyCoinsRepo)
+    monkeypatch.setattr(
+        run_module,
+        "_categories_cache_ts",
+        dt.datetime.now(dt.timezone.utc),
+    )
+    monkeypatch.setattr(run_module, "_categories_cache", {})
 
     class PagedClient:
         def __init__(self) -> None:
@@ -451,11 +457,84 @@ def test_run_etl_backfills_missing_categories(monkeypatch, tmp_path):
     session.close()
     assert names == ["Layer 1"]
     assert ids == ["layer-1"]
-    assert links == {}
+    assert links == {"__synced__": True}
 
     run_module.run_etl(client=client, budget=None)
     assert client.cat_calls == 1
     assert client.list_calls == 1
+
+
+def test_run_etl_backfills_missing_links(monkeypatch, tmp_path):
+    engine = create_engine(
+        f"sqlite:///{tmp_path/'test.db'}", connect_args={"check_same_thread": False}
+    )
+    TestingSessionLocal = sessionmaker(
+        bind=engine, autoflush=False, autocommit=False, expire_on_commit=False
+    )
+    Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    session.add(
+        Coin(
+            id="bitcoin",
+            symbol="btc",
+            name="Bitcoin",
+            category_names=json.dumps(["Layer 1"]),
+            category_ids=json.dumps(["layer-1"]),
+            social_links=json.dumps({}),
+            updated_at=dt.datetime.now(dt.timezone.utc) - dt.timedelta(hours=1),
+        )
+    )
+    session.commit()
+    session.close()
+
+    monkeypatch.setattr(run_module, "SessionLocal", TestingSessionLocal)
+    monkeypatch.setattr(run_module, "_categories_cache", {})
+    monkeypatch.setattr(run_module, "_categories_cache_ts", None)
+
+    class StubClient:
+        def __init__(self) -> None:
+            self.profile_calls = 0
+
+        def get_markets(self, *, vs, per_page, page):
+            return [
+                {
+                    "id": "bitcoin",
+                    "symbol": "btc",
+                    "name": "Bitcoin",
+                    "current_price": 1.0,
+                    "market_cap": 2.0,
+                    "total_volume": 3.0,
+                    "market_cap_rank": 1,
+                    "price_change_percentage_24h": 4.0,
+                }
+            ]
+
+        def get_categories_list(self):
+            return []
+
+        def get_coin_profile(self, coin_id: str):
+            self.profile_calls += 1
+            return {
+                "categories": ["Layer 1"],
+                "links": {"website": "https://bitcoin.org"},
+            }
+
+    client = StubClient()
+    run_module.run_etl(client=client, budget=None)
+    assert client.profile_calls == 1
+
+    session = TestingSessionLocal()
+    names, ids, links, _ = run_module.CoinsRepo(session).get_categories_with_timestamp(
+        "bitcoin"
+    )
+    session.close()
+    assert names == ["Layer 1"]
+    assert ids == ["layer-1"]
+    assert links.get("website") == "https://bitcoin.org"
+    assert "__synced__" not in links
+
+    run_module.run_etl(client=client, budget=None)
+    assert client.profile_calls == 1
 
 
 def test_run_etl_retries_on_429(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- treat coins with missing cached social links as stale and fetch their CoinGecko profile once, storing a sentinel when the API returns no links
- extend ETL tests to cover the backfill flow, adjust existing expectations for the sentinel, and keep API call accounting stable

## Testing
- pytest
- node --test tests/*.js

------
https://chatgpt.com/codex/tasks/task_e_68d056a3a7748327860ebc1d27930f2f