### PR TITLE
fix: preserve categories when profile fetch fails

### DIFF
--- a/backend/app/etl/run.py
+++ b/backend/app/etl/run.py
@@ -191,7 +191,10 @@ def run_etl(
             ids = [mapping.get(slugify(n), slugify(n)) for n in names]
             links_obj = profile.get("links")
             links = links_obj if isinstance(links_obj, dict) else {}
-            if fetched_profile and not links:
+            if not fetched_profile:
+                names, ids = cached_names, cached_ids
+                links = cached_links
+            elif not links:
                 links = {"__synced__": True}
         else:
             names, ids = cached_names, cached_ids


### PR DESCRIPTION
## Summary
- keep cached category assignments when the CoinGecko profile request fails during a link backfill
- add a regression test covering the fallback behaviour when the profile call raises an HTTP error

## Testing
- pytest
- node --test tests/*.js

------
https://chatgpt.com/codex/tasks/task_e_68d05e469d288327aa4e77f1a57ae0f4