### PR TITLE
fix: honor refresh windows before hitting external apis

### DIFF
--- a/backend/app/utils/time.py
+++ b/backend/app/utils/time.py
@@ -1,0 +1,29 @@
+"""Time-related utility helpers reused across the application."""
+
+from __future__ import annotations
+
+DEFAULT_REFRESH_SECONDS = 12 * 60 * 60
+
+
+def refresh_interval_seconds(value: str | None, *, default: int = DEFAULT_REFRESH_SECONDS) -> int:
+    """Convert ``value`` like ``"12h"`` to seconds, falling back to ``default``.
+
+    The function mirrors :func:`backend.app.main.refresh_interval_seconds` semantics
+    so existing behaviour remains unchanged.
+    """
+
+    if value is None:
+        return default
+    text = str(value).strip()
+    if not text:
+        return default
+    try:
+        if text.endswith("h"):
+            hours = float(text[:-1])
+            return int(hours * 60 * 60)
+    except Exception:  # pragma: no cover - defensive fallback
+        return default
+    return default
+
+
+__all__ = ["refresh_interval_seconds", "DEFAULT_REFRESH_SECONDS"]


### PR DESCRIPTION
## Summary
- skip the market ETL when the last refresh is still within the configured cadence and only refresh coin profiles when metadata is older than 30 days
- add a shared helper for parsing refresh granularities and ensure the fear & greed synchroniser obeys the same freshness guard
- extend the ETL and fear & greed test suites with scenarios covering the new short-circuit behaviour

## Testing
- pytest -q
- node --test tests/*.js


------
https://chatgpt.com/codex/tasks/task_e_68d06d50a2b0832787bd5f845b47e3aa