### PR TITLE
feat(etl): add historical price import

### DIFF
--- a/backend/app/etl/historical_import.py
+++ b/backend/app/etl/historical_import.py
@@ -1,0 +1,167 @@
+"""One-off utilities to load historical CSV data into the database."""
+
+from __future__ import annotations
+
+import csv
+import datetime as dt
+from pathlib import Path
+from typing import Iterable, Iterator, Mapping
+
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as postgres_insert
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlalchemy.orm import Session
+
+from ..models import Coin, Price
+
+_DEFAULT_DATA_DIR = Path(__file__).resolve().parents[2] / "Historical_Data"
+
+
+def _iter_csv_rows(path: Path) -> Iterator[list[str]]:
+    with path.open("r", encoding="utf-8") as handle:
+        for raw in handle:
+            cleaned = raw.strip()
+            if not cleaned:
+                continue
+            if cleaned.startswith("\ufeff"):
+                cleaned = cleaned.lstrip("\ufeff")
+            if cleaned.startswith('"') and cleaned.endswith('"'):
+                cleaned = cleaned[1:-1]
+            cleaned = cleaned.replace('""', '"')
+            try:
+                row = next(csv.reader([cleaned]))
+            except csv.Error:
+                continue
+            if row:
+                yield row
+
+
+def _build_coin_index(session: Session) -> Mapping[str, str]:
+    rows = session.execute(select(Coin.id, Coin.name)).all()
+    index: dict[str, str] = {}
+    for coin_id, name in rows:
+        if not name:
+            continue
+        index[name.casefold()] = coin_id
+    return index
+
+
+def _parse_timestamp(raw: str) -> dt.datetime | None:
+    try:
+        timestamp = dt.datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if timestamp.tzinfo is None:
+        return timestamp.replace(tzinfo=dt.timezone.utc)
+    return timestamp.astimezone(dt.timezone.utc)
+
+
+def _to_float(raw: str) -> float | None:
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def _upsert_prices(session: Session, rows: list[dict[str, object]]) -> None:
+    if not rows:
+        return
+    bind = session.get_bind()
+    dialect = getattr(getattr(bind, "dialect", None), "name", "") if bind else ""
+    if dialect == "sqlite":
+        stmt = sqlite_insert(Price).values(rows)
+    elif dialect in {"postgresql", "postgres"}:
+        stmt = postgres_insert(Price).values(rows)
+    else:
+        raise NotImplementedError(
+            "Unsupported database dialect for historical import: " f"{dialect!r}"
+        )
+    stmt = stmt.on_conflict_do_update(
+        index_elements=[Price.coin_id, Price.vs_currency, Price.snapshot_at],
+        set_={
+            "price": stmt.excluded.price,
+            "volume_24h": stmt.excluded.volume_24h,
+        },
+    )
+    session.execute(stmt)
+
+
+def _collect_csv_files(
+    csv_files: Iterable[Path] | None = None, data_dir: Path | None = None
+) -> list[Path]:
+    if csv_files is not None:
+        return [Path(path) for path in csv_files]
+    base_dir = data_dir or _DEFAULT_DATA_DIR
+    if not base_dir.exists():
+        return []
+    return sorted(base_dir.glob("*.csv"))
+
+
+def import_historical_data(
+    session: Session,
+    csv_files: Iterable[Path] | None = None,
+    data_dir: Path | None = None,
+) -> int:
+    """Load historical closing price and volume data into the database."""
+
+    files = _collect_csv_files(csv_files, data_dir)
+    if not files:
+        return 0
+
+    name_to_coin = _build_coin_index(session)
+    buffered: dict[tuple[str, str, dt.datetime], dict[str, object]] = {}
+
+    for file_path in files:
+        rows_iter = _iter_csv_rows(file_path)
+        try:
+            header = next(rows_iter)
+        except StopIteration:
+            continue
+        field_count = len(header)
+        for row in rows_iter:
+            if len(row) != field_count:
+                continue
+            raw_timestamp, *_rest = row
+            timestamp = _parse_timestamp(raw_timestamp)
+            if timestamp is None:
+                continue
+            close_raw = row[4]
+            volume_raw = row[5]
+            ticker = row[6].strip()
+            name = row[7].strip()
+            coin_id = name_to_coin.get(name.casefold())
+            if coin_id is None:
+                continue
+            price = _to_float(close_raw)
+            volume = _to_float(volume_raw)
+            if price is None or volume is None:
+                continue
+            if "-" in ticker:
+                vs_currency = ticker.split("-", 1)[1].lower()
+            else:
+                vs_currency = "usd"
+            key = (coin_id, vs_currency, timestamp)
+            buffered[key] = {
+                "coin_id": coin_id,
+                "vs_currency": vs_currency,
+                "snapshot_at": timestamp,
+                "price": price,
+                "volume_24h": volume,
+                "market_cap": None,
+                "fully_diluted_market_cap": None,
+                "rank": None,
+                "pct_change_24h": None,
+                "pct_change_7d": None,
+                "pct_change_30d": None,
+            }
+
+    rows = list(buffered.values())
+    if not rows:
+        return 0
+
+    _upsert_prices(session, rows)
+    session.commit()
+    return len(rows)
+
+
+__all__ = ["import_historical_data"]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -31,6 +31,7 @@ from .core.scheduling import (
 )
 from .core.version import get_version
 from .db import Base, engine, get_session
+from .etl.historical_import import import_historical_data
 from .etl.run import DataUnavailable, load_seed, run_etl
 from .schemas.version import VersionResponse
 from .models import FearGreed
@@ -791,6 +792,11 @@ async def startup() -> None:
     app.state.cmc_budget = cmc_budget
 
     session = next(get_session())
+    # HISTORICAL_IMPORT: temporary bootstrap hook, delete once CSV backfill is done.
+    try:
+        import_historical_data(session)
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.warning("historical import skipped: %s", exc)
     meta_repo = MetaRepo(session)
     prices_repo = PricesRepo(session)
     path_taken = "skip"

--- a/tests/test_historical_import.py
+++ b/tests/test_historical_import.py
@@ -1,0 +1,87 @@
+import datetime as dt
+from pathlib import Path
+
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+from backend.app.db import Base
+from backend.app.models import Coin, Price
+
+
+def _setup_session(tmp_path: Path) -> sessionmaker:
+    engine = create_engine(
+        f"sqlite:///{tmp_path/'hist.db'}", connect_args={"check_same_thread": False}
+    )
+    TestingSession = sessionmaker(
+        bind=engine, autoflush=False, autocommit=False, expire_on_commit=False
+    )
+    Base.metadata.create_all(bind=engine)
+    return TestingSession
+
+
+def _write_csv(path: Path) -> None:
+    path.write_text(
+        "\n".join(
+            [
+                '"Date,""Open"",""High"",""Low"",""Close"",""Volume"",""ticker"",""name"""',
+                '"2024-01-01 00:00:00+00:00,""1"",""1"",""1"",""2.5"",""123"",""AAA-USD"",""Alpha"""',
+                '"2024-01-02 00:00:00+00:00,""1"",""1"",""1"",""4"",""456"",""AAA-USD"",""ALPHA"""',
+                '"invalid,""1"",""1"",""1"",""5"",""789"",""AAA-USD"",""Alpha"""',
+                '"2024-01-01 00:00:00+00:00,""1"",""1"",""1"",""3"",""999"",""BBB-USD"",""Missing Coin"""',
+            ]
+        )
+        + "\n"
+    )
+
+
+def test_import_historical_data_inserts_prices(tmp_path):
+    TestingSession = _setup_session(tmp_path)
+    csv_path = tmp_path / "hist.csv"
+    _write_csv(csv_path)
+
+    from backend.app.etl import historical_import
+
+    session = TestingSession()
+    session.add(Coin(id="alpha", symbol="AAA", name="Alpha"))
+    session.commit()
+
+    inserted = historical_import.import_historical_data(session, [csv_path])
+
+    rows = session.execute(select(Price)).scalars().all()
+    assert inserted == 2
+    assert len(rows) == 2
+
+    def _normalize(ts: dt.datetime) -> dt.datetime:
+        return ts if ts.tzinfo is not None else ts.replace(tzinfo=dt.timezone.utc)
+
+    by_date = {_normalize(row.snapshot_at): row for row in rows}
+    first_ts = dt.datetime(2024, 1, 1, tzinfo=dt.timezone.utc)
+    second_ts = dt.datetime(2024, 1, 2, tzinfo=dt.timezone.utc)
+
+    assert by_date[first_ts].price == 2.5
+    assert by_date[first_ts].volume_24h == 123
+    assert by_date[second_ts].price == 4
+    assert by_date[second_ts].volume_24h == 456
+
+    session.close()
+
+
+def test_import_historical_data_skips_unknown_coins(tmp_path):
+    TestingSession = _setup_session(tmp_path)
+    csv_path = tmp_path / "hist.csv"
+    _write_csv(csv_path)
+
+    from backend.app.etl import historical_import
+
+    session = TestingSession()
+    session.add(Coin(id="beta", symbol="BBB", name="Beta"))
+    session.commit()
+
+    inserted = historical_import.import_historical_data(session, [csv_path])
+
+    rows = session.execute(select(Price)).scalars().all()
+    assert inserted == 0
+    assert rows == []
+
+    session.close()
+


### PR DESCRIPTION
## Summary
- add a dedicated importer to load historical CSV prices/volume into the prices table
- support configurable CSV sources and robust parsing/upsert logic keyed by coin name
- cover the importer with unit tests ensuring valid rows load and unknown coins are skipped
- trigger the historical backfill from FastAPI startup with a clearly marked temporary hook

## Testing
- pytest
- node --test tests/*.js

------
https://chatgpt.com/codex/tasks/task_e_68d595939840832799b48a453923c1ab