### PR TITLE
Improve Fear & Greed diagnostics resilience

### DIFF
--- a/frontend/debug.html
+++ b/frontend/debug.html
@@ -145,6 +145,67 @@
       color: var(--text-primary);
     }
 
+    section.providers-section {
+      background: var(--surface-card);
+      border: 1px solid var(--border-subtle);
+      border-radius: 12px;
+      padding: 1.25rem;
+      box-shadow: var(--shadow-soft);
+    }
+
+    .providers-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 1rem;
+      margin: 0;
+      padding: 0;
+    }
+
+    .provider-card {
+      border: 1px solid var(--border-subtle);
+      border-radius: 10px;
+      padding: 1rem;
+      background: var(--surface-subtle, var(--surface-card));
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+
+    .provider-card h3 {
+      margin: 0;
+      font-size: 1.05rem;
+    }
+
+    .provider-card p {
+      margin: 0;
+      color: var(--text-muted);
+      font-size: 0.9rem;
+    }
+
+    .provider-endpoints {
+      list-style: none;
+      margin: 0.25rem 0 0;
+      padding: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+
+    .provider-endpoints li {
+      font-size: 0.85rem;
+      color: var(--text-primary);
+    }
+
+    .provider-endpoints a {
+      color: var(--accent, #2563eb);
+      text-decoration: none;
+    }
+
+    .provider-endpoints a:hover,
+    .provider-endpoints a:focus {
+      text-decoration: underline;
+    }
+
     @media (max-width: 600px) {
       body {
         padding: 1.5rem;
@@ -156,6 +217,10 @@
       }
 
       section.info-grid dl {
+        grid-template-columns: 1fr;
+      }
+
+      .providers-grid {
         grid-template-columns: 1fr;
       }
     }
@@ -191,6 +256,13 @@
           </ul>
         </div>
       </article>
+    </section>
+
+    <section class="providers-section" aria-label="Fournisseurs d'API">
+      <h2>Fournisseurs d'API</h2>
+      <div id="providers-list" class="providers-grid">
+        <p>Aucun fournisseur configuré</p>
+      </div>
     </section>
 
     <section class="info-grid" aria-label="Métadonnées de la plateforme">

--- a/frontend/fear-greed.html
+++ b/frontend/fear-greed.html
@@ -24,6 +24,7 @@
           <span>Sentiment actuel</span>
           <strong id="fear-greed-value">—</strong>
         </div>
+        <div id="fear-greed-error" class="sentiment-error" hidden>Fear &amp; Greed indisponible</div>
         <div class="sentiment-visual">
           <div id="fear-greed-gauge" class="sentiment-gauge" aria-hidden="true"></div>
           <ul class="sentiment-legend">
@@ -91,9 +92,11 @@
             <p>Suivez la variation de l'indice sur différentes périodes.</p>
           </div>
           <div class="range-selector" id="fear-greed-range" role="radiogroup" aria-label="Période de l'historique">
-            <button type="button" data-range="30d" aria-pressed="false">30j</button>
-            <button type="button" data-range="90d" aria-pressed="false">90j</button>
+            <button type="button" data-range="1m" aria-pressed="false">1 mois</button>
+            <button type="button" data-range="3m" aria-pressed="false">3 mois</button>
+            <button type="button" data-range="6m" aria-pressed="false">6 mois</button>
             <button type="button" data-range="1y" aria-pressed="false">1 an</button>
+            <button type="button" data-range="ytd" aria-pressed="false">YTD</button>
             <button type="button" data-range="max" aria-pressed="false">Totalité</button>
           </div>
         </div>

--- a/frontend/theme.css
+++ b/frontend/theme.css
@@ -245,6 +245,16 @@ a:hover {
   font-weight: 700;
 }
 
+.sentiment-error {
+  display: block;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  background: var(--status-error-bg);
+  color: var(--status-error-text);
+  font-weight: 600;
+  margin: 0 0 0.5rem;
+}
+
 .sentiment-classification {
   font-size: 1rem;
   font-weight: 600;


### PR DESCRIPTION
## Summary
- add retrying, timeout and structured logging to the CoinMarketCap Fear & Greed client while emitting ISO8601Z timestamps
- normalize Fear & Greed payloads across the API, extend diagnostics reporting and add responsive provider debug UI
- expand unit and integration coverage for backend normalization paths and frontend diagnostics rendering

## Testing
- pytest
- node --test tests/*.js

------
https://chatgpt.com/codex/tasks/task_e_68d8d63f377883279d77b59658924a67