### PR TITLE
fix: derive CoinGecko credit usage from budget snapshot

### DIFF
--- a/backend/app/clients/cmc_fng.py
+++ b/backend/app/clients/cmc_fng.py
@@ -177,7 +177,12 @@ class CoinMarketCapFearGreedClient:
     ) -> tuple[dict[str, Any], dt.datetime] | None:
         if not isinstance(entry, dict):
             return None
-        timestamp_raw = entry.get("timestamp") or entry.get("time")
+        timestamp_raw = (
+            entry.get("timestamp")
+            or entry.get("time")
+            or entry.get("update_time")
+            or entry.get("updateTime")
+        )
         parsed_timestamp = _parse_timestamp(timestamp_raw)
         if parsed_timestamp is None:
             return None

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -1,3 +1,5 @@
+import json
+
 from backend.app.services.budget import CallBudget
 
 
@@ -10,7 +12,7 @@ def test_budget_spend_and_reset(tmp_path, monkeypatch):
     assert not budget.can_spend(3)
 
     # simulate new month
-    monkeypatch.setattr(budget, "_current_month", lambda: "2099-12")
+    monkeypatch.setattr(budget, "_current_month", lambda: "2099-12-01")
     assert budget.can_spend(5)
     budget.spend(5)
     assert budget.monthly_call_count == 5
@@ -33,6 +35,50 @@ def test_budget_tracks_category_breakdown(tmp_path, monkeypatch):
         "uncategorized": 1,
     }
 
-    monkeypatch.setattr(budget, "_current_month", lambda: "2100-01")
+    monkeypatch.setattr(budget, "_current_month", lambda: "2100-01-01")
     assert budget.can_spend(1)
     assert budget.category_counts == {}
+
+
+def test_budget_sync_usage_overrides_counts(tmp_path, monkeypatch):
+    path = tmp_path / "budget.json"
+    budget = CallBudget(path, quota=50)
+
+    budget.spend(5, category="markets")
+    assert path.read_text()
+
+    budget.sync_usage(monthly_call_count=42, categories={"markets": 40, "misc": 2})
+
+    assert budget.monthly_call_count == 42
+    assert budget.category_counts == {"markets": 40, "misc": 2}
+
+
+def test_budget_sync_usage_ignores_invalid_data(tmp_path):
+    path = tmp_path / "budget.json"
+    budget = CallBudget(path, quota=50)
+
+    budget.sync_usage(monthly_call_count=None, categories=None)
+    assert budget.monthly_call_count == 0
+    assert budget.category_counts == {}
+
+    budget.sync_usage(monthly_call_count=-10, categories={"": -5, "markets": "invalid"})
+    assert budget.monthly_call_count == 0
+    assert budget.category_counts == {}
+
+
+def test_budget_month_uses_first_day(tmp_path):
+    path = tmp_path / "budget.json"
+    budget = CallBudget(path, quota=50)
+
+    budget.sync_usage(monthly_call_count=0)
+    payload = json.loads(path.read_text())
+    assert payload["month"].endswith("-01")
+
+    # simulate persisted payload with old-style month
+    path.write_text(json.dumps({"month": "1999-05", "monthly_call_count": 3, "categories": {}}))
+    reloaded = CallBudget(path, quota=50)
+    # old month triggers reset
+    assert reloaded.monthly_call_count == 0
+    reloaded.sync_usage(monthly_call_count=0)
+    reloaded_payload = json.loads(path.read_text())
+    assert reloaded_payload["month"].endswith("-01")

--- a/tests/test_fear_greed.py
+++ b/tests/test_fear_greed.py
@@ -76,6 +76,24 @@ def test_fear_greed_repo_upsert_and_history(TestingSessionLocal):
     session.close()
 
 
+def test_normalize_fng_payload_supports_update_time() -> None:
+    import backend.app.main as main_module
+
+    payload = {
+        "value": 34,
+        "update_time": "2025-09-28T10:23:10.053Z",
+        "value_classification": "Fear",
+    }
+
+    normalized = main_module._normalize_fng_payload(payload)
+
+    assert normalized == {
+        "timestamp": "2025-09-28T10:23:10.053000Z",
+        "score": 34,
+        "label": "Fear",
+    }
+
+
 def test_api_fng_latest_success(monkeypatch, TestingSessionLocal):
     import backend.app.main as main_module
 


### PR DESCRIPTION
## Summary
- derive CoinGecko credit usage from local budgets and report reset dates alongside CoinMarketCap metrics
- normalize CallBudget month values to the first day and expose month_start for reset calculations
- refresh diagnostics/tests to reflect budget-based CoinGecko usage and first-of-month resets

## Testing
- pytest -q
- node --test tests/*.js

------
https://chatgpt.com/codex/tasks/task_e_68d905954bf0832787029c86175990ca